### PR TITLE
Mark 2.7.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "build.gradle.kts" }}
             - v1-dependencies-
-      - run: ./gradlew release -Prelease.customUsername=${github_pushback_personal_token}
+      - run: ./gradlew release
       - run: ./gradlew publish
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.7.0...master
+[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.7.1...master
+
+## [2.7.1] - 2019-03-19
+[2.7.1]: https://github.com/atlassian/aws-infrastructure/compare/release-2.7.0...release-2.7.1
 
 ### Fixed
 - Copy the `databaseComputer` in Jira formula builders.


### PR DESCRIPTION
CircleCI [checks out via SSH rather than HTTPS](https://circleci.com/docs/2.0/configuration-reference/#checkout).
In order to push back they use SSH user keys. Therefore the HTTPS pushback token is not necessary.