### PR TITLE
Allow jira-config.properties file to become part of the dataset.

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
@@ -52,7 +52,8 @@ internal class StandaloneNodeFormula(
                 jiraIp = ssh.host.ipAddress
             )
             connection.execute("echo jira.home=`realpath $jiraHome` > $unpackedProduct/atlassian-jira/WEB-INF/classes/jira-application.properties")
-            connection.execute("echo jira.autoexport=false > $jiraHome/jira-config.properties")
+            connection.execute("touch $jiraHome/jira-config.properties")
+            connection.execute("grep -qxF \"jira.autoexport=false\" $jiraHome/jira-config.properties || echo -e \"\\njira.autoexport=false\" >> $jiraHome/jira-config.properties")
             downloadMysqlConnector(
                 "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz",
                 connection


### PR DESCRIPTION
The autoexport property will be added only if it does not already exist in the file or the file does not exist at all. In other words, the jira-config.properties file that has already been restored with the dataset will remain unchanged or will get the autoexport=false property appended to it.