### PR TITLE
QUICK-221 Make S3DatasetPackage public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
+
+### Added
+
+- Makes `S3DatasetPackage` available as part of API
+
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.12.1...master
 
 ## [2.12.1] - 2019-07-09

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
@@ -1,7 +1,7 @@
 package com.atlassian.performance.tools.awsinfrastructure.api
 
 import com.atlassian.performance.tools.aws.api.StorageLocation
-import com.atlassian.performance.tools.awsinfrastructure.S3DatasetPackage
+import com.atlassian.performance.tools.awsinfrastructure.api.dataset.S3DatasetPackage
 import com.atlassian.performance.tools.infrastructure.api.database.LicenseOverridingMysql
 import com.atlassian.performance.tools.infrastructure.api.database.MySqlDatabase
 import com.atlassian.performance.tools.infrastructure.api.dataset.Dataset

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/dataset/S3DatasetPackage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/dataset/S3DatasetPackage.kt
@@ -1,16 +1,21 @@
-package com.atlassian.performance.tools.awsinfrastructure
+package com.atlassian.performance.tools.awsinfrastructure.api.dataset
 
 import com.atlassian.performance.tools.aws.api.StorageLocation
+import com.atlassian.performance.tools.awsinfrastructure.AwsCli
 import com.atlassian.performance.tools.infrastructure.api.dataset.DatasetPackage
 import com.atlassian.performance.tools.infrastructure.api.dataset.FileArchiver
 import com.atlassian.performance.tools.jvmtasks.api.TaskTimer.time
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import java.time.Duration
 
-internal data class S3DatasetPackage(
+/**
+ * Downloads dataset from S3 and unzips on the remote machine.
+ * Requires valid AWS credentials.
+ */
+class S3DatasetPackage(
     private val artifactName: String,
     private val location: StorageLocation,
-    private val unpackedPath: String? = null,
+    private val unpackedPath: String,
     private val downloadTimeout: Duration
 ) : DatasetPackage {
 
@@ -26,6 +31,6 @@ internal data class S3DatasetPackage(
             ssh.execute("$downloadFileCommand | $unzipCommand", downloadTimeout)
         }
 
-        return unpackedPath!!
+        return unpackedPath
     }
 }


### PR DESCRIPTION
Moved the class into the api package.
Tidied the API by removing data class definition.