### PR TITLE
Fix `AwsCliIT` flakiness

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/AwsCliIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/AwsCliIT.kt
@@ -67,7 +67,7 @@ class AwsCliIT {
                 }
             }
         }.map {
-            Assertions.catchThrowable { it.get(60, TimeUnit.SECONDS) }
+            Assertions.catchThrowable { it.get(2, TimeUnit.MINUTES) }
         }
 
         Assertions.assertThat(ensureCliErrors).containsOnlyNulls()


### PR DESCRIPTION
The initial timeout was not measured well. I run the test a couple
times and it was fine. 1 minute may not be enough:
https://circleci.com/gh/atlassian/aws-infrastructure/57