### PR TITLE
JPERF-579: Add `ProvisionedJiraFormula`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.17.0...master
 
+### Added
+- Add `ProvisionedJiraFormula`. Resolve [JPERF-579].
+
+[JPERF-579]: https://ecosystem.atlassian.net/browse/JPERF-579
+
 ## [2.17.0] - 2019-09-04
 [2.17.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.16.0...release-2.17.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/ProvisionedJiraFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/ProvisionedJiraFormula.kt
@@ -1,0 +1,20 @@
+package com.atlassian.performance.tools.awsinfrastructure.api.jira
+
+import com.atlassian.performance.tools.aws.api.Aws
+import com.atlassian.performance.tools.aws.api.Investment
+import com.atlassian.performance.tools.aws.api.SshKey
+import com.atlassian.performance.tools.aws.api.Storage
+import java.util.concurrent.Future
+
+class ProvisionedJiraFormula(
+    private val provisionedJira: ProvisionedJira
+) : JiraFormula {
+    override fun provision(
+        investment: Investment,
+        pluginsTransport: Storage,
+        resultsTransport: Storage,
+        key: Future<SshKey>,
+        roleProfile: String,
+        aws: Aws
+    ): ProvisionedJira = provisionedJira
+}


### PR DESCRIPTION
Alternative to https://github.com/atlassian/aws-infrastructure/pull/57
No nulls, no NPE checks, no elvises, no extra constructors.
Still keeps feature set open to further extension without generating permutations of optional parameters.