### PR TITLE
JPERF-579: Enables infrastructure formula to be created with user pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.17.0...master
 
+### Added
+- Expose API to create InfrastructureFormula with user provisioned Jira. Resolve [JPERF-579].
+
+[JPERF-579]: https://ecosystem.atlassian.net/browse/JPERF-579
+
 ## [2.17.0] - 2019-09-04
 [2.17.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.16.0...release-2.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,6 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.17.0...master
 
-### Added
-- Expose API to create InfrastructureFormula with user provisioned Jira. Resolve [JPERF-579].
-
-[JPERF-579]: https://ecosystem.atlassian.net/browse/JPERF-579
-
 ## [2.17.0] - 2019-09-04
 [2.17.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.16.0...release-2.17.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -3,7 +3,6 @@ package com.atlassian.performance.tools.awsinfrastructure.api
 import com.atlassian.performance.tools.aws.api.*
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.DataCenterFormula
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.JiraFormula
-import com.atlassian.performance.tools.awsinfrastructure.api.jira.ProvisionedJira
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.StandaloneFormula
 import com.atlassian.performance.tools.awsinfrastructure.api.network.Network
 import com.atlassian.performance.tools.awsinfrastructure.api.network.NetworkFormula
@@ -28,24 +27,12 @@ import java.util.concurrent.Executors
  * - [Ec2VirtualUsersFormula]
  * - [MulticastVirtualUsersFormula]
  */
-class InfrastructureFormula<out T : VirtualUsers> private constructor(
+class InfrastructureFormula<out T : VirtualUsers>(
     private val investment: Investment,
-    private val jiraFormula: JiraFormula?,
-    private val userProvisionedJira: ProvisionedJira?,
+    private val jiraFormula: JiraFormula,
     private val virtualUsersFormula: VirtualUsersFormula<T>,
     private val aws: Aws
 ) {
-
-    constructor(investment: Investment,
-                userProvisionedJira: ProvisionedJira,
-                virtualUsersFormula: VirtualUsersFormula<T>,
-                aws: Aws) : this(investment, null, userProvisionedJira, virtualUsersFormula, aws)
-
-    constructor(investment: Investment,
-                jiraFormula: JiraFormula,
-                virtualUsersFormula: VirtualUsersFormula<T>,
-                aws: Aws) : this(investment, jiraFormula, null, virtualUsersFormula, aws)
-
     fun provision(
         workingDirectory: Path
     ): ProvisionedInfrastructure<T> {
@@ -72,9 +59,8 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
         }
 
         val network = networkProvisioning.get()
-
-        val provisionedJira =  userProvisionedJira ?: executor.submitWithLogContext("jira") {
-            overrideJiraNetwork(network)!!.provision(
+        val provisionJira = executor.submitWithLogContext("jira") {
+            overrideJiraNetwork(network).provision(
                 investment = investment,
                 pluginsTransport = aws.jiraStorage(nonce),
                 resultsTransport = resultsStorage,
@@ -82,7 +68,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
                 roleProfile = roleProfile,
                 aws = aws
             )
-        }.get()
+        }
 
         val provisionVirtualUsers = executor.submitWithLogContext("virtual users") {
             overrideVuNetwork(network).provision(
@@ -97,6 +83,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
             )
         }
 
+        val provisionedJira = provisionJira.get()
         val provisionedVirtualUsers = provisionVirtualUsers.get()
         val sshKey = keyProvisioning.get()
 
@@ -121,7 +108,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
 
     private fun overrideJiraNetwork(
         network: Network
-    ): JiraFormula? = when (jiraFormula) {
+    ): JiraFormula = when (jiraFormula) {
         is DataCenterFormula -> DataCenterFormula.Builder(jiraFormula).network(network).build()
         is StandaloneFormula -> StandaloneFormula.Builder(jiraFormula).network(network).build()
         else -> jiraFormula


### PR DESCRIPTION
…visioned Jira

There were several situations when JPT tests should run over existing jira. It is possible through various hacks, which always end on not merged branches, then knowledge is lost.

It also reverts previous commit related to this issue and brings proper concurrency to VU and Jira provisioning jobs.