### PR TITLE
JPT-478: Improve stopJira to wait for Jira process only

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
@@ -88,8 +88,10 @@ class CustomDatasetSource(
 
     private fun stopJira(host: SshHost) {
         val shutdownTomcat = "echo SHUTDOWN | nc localhost 8005"
-        val waitForNoJavaProcess = "while ps -C java -o pid=; do sleep 5; done"
-        Ssh(host, connectivityPatience = 4).newConnection().use { it.safeExecute("$shutdownTomcat && $waitForNoJavaProcess", Duration.ofMinutes(3)) }
+        val waitForNoJiraProcess = "while pgrep -f jira; do sleep 5; done"
+        Ssh(host, connectivityPatience = 4).newConnection().use {
+            it.safeExecute("$shutdownTomcat && $waitForNoJiraProcess", Duration.ofMinutes(3))
+        }
     }
 
     private fun stopDockerContainers(host: SshHost) {


### PR DESCRIPTION
JPT-478: Improve stopJira to wait for Jira process to shutdown instead of all Java processes on the node