### PR TITLE
Revert "JPERF-637: Do not specify availability zones when requesting AWS stack creation (#90)"

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/AvaliabilityZonePicker.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/AvaliabilityZonePicker.kt
@@ -1,0 +1,21 @@
+package com.atlassian.performance.tools.awsinfrastructure
+
+import com.amazonaws.services.ec2.model.AvailabilityZone
+import com.atlassian.performance.tools.aws.api.Aws
+import org.apache.logging.log4j.LogManager
+
+/**
+ * Randomizing helps spread resources over a wider capacity pool.
+ * We avoid `eu-central-1c` AZ because it runs out of c4.8xlarge capacity all the time.
+ */
+internal fun Aws.pickAvailabilityZone(): AvailabilityZone {
+    val logger = LogManager.getLogger(this::class.java)
+
+    val zone = this
+        .availabilityZones
+        .filter { it.zoneName != "eu-central-1c" }
+        .shuffled()
+        .first()
+    logger.debug("Picked $zone")
+    return zone
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
@@ -1,8 +1,10 @@
 package com.atlassian.performance.tools.awsinfrastructure.api.network
 
+import com.amazonaws.services.cloudformation.model.Parameter
 import com.atlassian.performance.tools.aws.api.Aws
 import com.atlassian.performance.tools.aws.api.Investment
 import com.atlassian.performance.tools.aws.api.StackFormula
+import com.atlassian.performance.tools.awsinfrastructure.pickAvailabilityZone
 import com.atlassian.performance.tools.io.api.readResourceText
 import org.apache.logging.log4j.LogManager
 
@@ -19,7 +21,12 @@ class NetworkFormula(
         val stackFormula = StackFormula(
             investment = investment,
             aws = aws,
-            cloudformationTemplate = readResourceText("aws/network.yaml")
+            cloudformationTemplate = readResourceText("aws/network.yaml"),
+            parameters = listOf(
+                Parameter()
+                    .withParameterKey("AvailabilityZone")
+                    .withParameterValue(aws.pickAvailabilityZone().zoneName)
+            )
         )
         logger.info("Provisioning network...")
         val stack = stackFormula.provision()

--- a/src/main/resources/aws/network.yaml
+++ b/src/main/resources/aws/network.yaml
@@ -1,5 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: A network for clustered services
+Parameters:
+  AvailabilityZone:
+    Type: AWS::EC2::AvailabilityZone::Name
 Resources:
   Vpc:
     Type: AWS::EC2::VPC
@@ -13,6 +16,7 @@ Resources:
       MapPublicIpOnLaunch: true
       CidrBlock: 10.0.0.0/24
       VpcId: !Ref Vpc
+      AvailabilityZone: !Ref AvailabilityZone
       Tags:
         - Key: Application
           Value:

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/IntegrationTestRuntime.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/IntegrationTestRuntime.kt
@@ -14,6 +14,7 @@ object IntegrationTestRuntime {
     init {
         ConfigurationFactory.setConfigurationFactory(LogConfigurationFactory(taskWorkspace))
         aws = Aws.Builder(Regions.EU_WEST_1)
+            .availabilityZoneFilter(Predicate { it.zoneName !in listOf("eu-west-1a") })
             .regionsWithHousekeeping(listOf(Regions.EU_WEST_1))
             .batchingCloudformationRefreshPeriod(Duration.ofSeconds(15))
             .build()


### PR DESCRIPTION
This reverts commit 81065af6f76b6bb896f5c136940bebeb7d3b1efb. Turns out we need to specify a zone as some zones don't support instance types that we request.