### PR TITLE
Upgrade virtual users to Ubuntu 20.04 Focal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.21.3...master
 
+### Fixed
+- Upgrade to Ubuntu 20.04 Focal in `StackVirtualUsersFormula`.
+
 ## [2.21.3] - 2020-07-03
 [2.21.3]: https://github.com/atlassian/aws-infrastructure/compare/release-2.21.2...release-2.21.3
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/AmiNameResolver.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/AmiNameResolver.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentMap
 
 internal class AmiNameResolver {
     companion object {
-        private const val vuAmiName = "ubuntu/images/hvm-ssd/ubuntu-eoan-19.10-amd64-server-20191204"
+        private const val vuAmiName = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200701"
 
         private val name2amiId: ConcurrentMap<AwsAndAmi, String> = ConcurrentHashMap()
 


### PR DESCRIPTION
This fixes a deadlock in xlib that takes out random number of Chrome browsers in tests longer than 30 minutes.