### PR TITLE
JPERF-632: Make mkfs.ext4 execution quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.1...master
 
+### Fixed
+- Quiet down mkfs.ext4 so that it doesn't pollute warn/error logs with version number string. Fix [JPERF-632].
+
+[JPERF-632]: https://ecosystem.atlassian.net/browse/JPERF-632
+
 ## [2.22.1] - 2020-11-27
 [2.22.1]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.0...2.22.1
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/hardware/EphemeralStorage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/hardware/EphemeralStorage.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 internal class EphemeralStorage {
     internal fun mount(ssh: SshConnection) {
         ssh.execute("sudo tar -cf /home/ubuntu.tar .")
-        ssh.execute("sudo mkfs.ext4 /dev/nvme1n1", Duration.ofMinutes(2))
+        ssh.execute("sudo mkfs.ext4 -q /dev/nvme1n1", Duration.ofMinutes(2))
         ssh.execute("sudo mount -t ext4 /dev/nvme1n1 /home/ubuntu")
         ssh.execute("sudo chown ubuntu /home/ubuntu")
         ssh.execute("cd /home/ubuntu")

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
@@ -128,18 +128,6 @@ internal class StandaloneNodeFormula(
         )
     }
 
-    private fun mountEphemeralDrive(
-        connection: SshConnection
-    ) {
-        connection.execute("sudo tar -cf /home/ubuntu.tar .")
-        connection.execute("sudo mkfs.ext4 /dev/nvme1n1")
-        connection.execute("sudo mount -t ext4 /dev/nvme1n1 /home/ubuntu")
-        connection.execute("sudo chown ubuntu /home/ubuntu")
-        connection.execute("cd /home/ubuntu")
-        connection.execute("tar -xf /home/ubuntu.tar")
-        connection.execute("sudo rm /home/ubuntu.tar")
-    }
-
     private fun downloadMysqlConnector(
         url: String,
         connection: SshConnection


### PR DESCRIPTION
This will get rid of the command printing out version number string (e.g. "mke2fs 1.42.13 (17-May-2015)") to stderr which then gets populated to logs as a warning. -q does not prevent the command from printing out to stderr actual errors though.

Also, remove unused, duplicated ephemeral storage creation code.