### PR TITLE
JPERF-3318 Enable EBS volume encryption

### DIFF
--- a/src/main/resources/aws/virtual-users.yaml
+++ b/src/main/resources/aws/virtual-users.yaml
@@ -39,6 +39,7 @@ Resources:
           Ebs:
             VolumeSize: 30
             VolumeType: gp2
+            Encrypted: true
   SshSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
The jces-1209 (JPT for cloud) will be running for EAP (Early access program) customer and as per the security team's suggestions, we need to encrypt the EBS volume.
I think I have already shared our solution plan in #help-jpt channel, but let me know if you need it then will share it.
Thanks