### PR TITLE
Feature/jperf 3374 parameterise ssh cidr ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.2...master
 
+### Added
+- Add the ability to parameterize CIDR IP range of SSH ingress to virtual user EC2 nodes for `virtual-users.yaml`
+
 ## [2.22.2] - 2020-12-07
 [2.22.2]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.1...2.22.2
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
@@ -143,7 +143,7 @@ class MulticastVirtualUsersFormula private constructor(
         fun network(network: Network) = apply { this.network = network }
         fun splunkForwarder(splunkForwarder: SplunkForwarder) = apply { this.splunkForwarder = splunkForwarder }
         fun instanceType(instanceType: InstanceType): MulticastVirtualUsersFormula.Builder = apply { this.instanceType = instanceType }
-        fun sshCidrIp(sshCidrIp: String): apply { this.sshCidrIp = sshCidrIp }
+        fun sshCidrIp(sshCidrIp: String) = apply { this.sshCidrIp = sshCidrIp }
 
         fun build(): VirtualUsersFormula<MulticastVirtualUsers<SshVirtualUsers>> = MulticastVirtualUsersFormula(
             nodes = nodes,

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
@@ -25,7 +25,8 @@ class MulticastVirtualUsersFormula private constructor(
     private val splunkForwarder: SplunkForwarder,
     private val browser: Browser,
     private val network: Network?,
-    private val instanceType: InstanceType
+    private val instanceType: InstanceType,
+    private val sshCidrIp: String
 ) : VirtualUsersFormula<MulticastVirtualUsers<SshVirtualUsers>> {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -84,6 +85,7 @@ class MulticastVirtualUsersFormula private constructor(
                         .splunkForwarder(splunkForwarder)
                         .browser(browser)
                         .instanceType(instanceType)
+                        .sshCidrIp(sshCidrIp)
                         .also { if (network != null) it.network(network) }
                         .build()
                         .provision(
@@ -116,6 +118,7 @@ class MulticastVirtualUsersFormula private constructor(
         private var network: Network? = null
         private var splunkForwarder: SplunkForwarder = DisabledSplunkForwarder()
         private var instanceType: InstanceType = InstanceType.C48xlarge
+        private var sshCidrIp: String = ""
 
         internal constructor(
             formula: MulticastVirtualUsersFormula
@@ -127,6 +130,7 @@ class MulticastVirtualUsersFormula private constructor(
             network = formula.network
             splunkForwarder = formula.splunkForwarder
             instanceType = formula.instanceType
+            sshCidrIp = formula.sshCidrIp
         }
 
         fun browser(browser: Browser) = apply { this.browser = browser }
@@ -137,6 +141,7 @@ class MulticastVirtualUsersFormula private constructor(
         fun network(network: Network) = apply { this.network = network }
         fun splunkForwarder(splunkForwarder: SplunkForwarder) = apply { this.splunkForwarder = splunkForwarder }
         fun instanceType(instanceType: InstanceType): MulticastVirtualUsersFormula.Builder = apply { this.instanceType = instanceType }
+        fun sshCidrIp(sshCidrIp: String): apply { this.sshCidrIp = sshCidrIp }
 
         fun build(): VirtualUsersFormula<MulticastVirtualUsers<SshVirtualUsers>> = MulticastVirtualUsersFormula(
             nodes = nodes,
@@ -144,7 +149,8 @@ class MulticastVirtualUsersFormula private constructor(
             splunkForwarder = splunkForwarder,
             browser = browser,
             network = network,
-            instanceType = instanceType
+            instanceType = instanceType,
+            sshCidrIp = sshCidrIp
         )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/MulticastVirtualUsersFormula.kt
@@ -42,7 +42,8 @@ class MulticastVirtualUsersFormula private constructor(
         splunkForwarder = splunkForwarder,
         browser = browser,
         network = null,
-        instanceType = InstanceType.C48xlarge
+        instanceType = InstanceType.C48xlarge,
+        sshCidrIp = ""
     )
 
     @Deprecated("Use MulticastVirtualUsersFormula.Builder")
@@ -55,7 +56,8 @@ class MulticastVirtualUsersFormula private constructor(
         splunkForwarder = DisabledSplunkForwarder(),
         browser = Chrome(),
         network = null,
-        instanceType = InstanceType.C48xlarge
+        instanceType = InstanceType.C48xlarge,
+        sshCidrIp = ""
     )
 
     override fun provision(

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
@@ -36,7 +36,8 @@ class StackVirtualUsersFormula private constructor(
     private val browser: Browser,
     private val stackCreationTimeout: Duration,
     private val overriddenNetwork: Network? = null,
-    private val instanceType: InstanceType
+    private val instanceType: InstanceType,
+    private val sshCidrIp: String
 ) : VirtualUsersFormula<SshVirtualUsers> {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -113,7 +114,10 @@ class StackVirtualUsersFormula private constructor(
                     .withParameterValue(network.subnet.subnetId),
                 Parameter()
                     .withParameterKey("InstanceType")
-                    .withParameterValue(instanceType.toString())
+                    .withParameterValue(instanceType.toString()),
+                Parameter()
+                    .withParameterKey("SSHCidrIp")
+                    .withParameterValue("")
             ),
             aws = aws,
             pollingTimeout = stackCreationTimeout
@@ -158,6 +162,7 @@ class StackVirtualUsersFormula private constructor(
         private var stackCreationTimeout: Duration = Duration.ofMinutes(30)
         private var network: Network? = null
         private var instanceType: InstanceType = InstanceType.C48xlarge
+        private var sshCidrIp: String = ""
 
         internal constructor(
             formula: StackVirtualUsersFormula
@@ -170,6 +175,7 @@ class StackVirtualUsersFormula private constructor(
             stackCreationTimeout = formula.stackCreationTimeout
             network = formula.overriddenNetwork
             instanceType = formula.instanceType
+            sshCidrIp = formula.sshCidrIp
         }
 
         fun nodeOrder(nodeOrder: Int): Builder = apply { this.nodeOrder = nodeOrder }
@@ -177,6 +183,7 @@ class StackVirtualUsersFormula private constructor(
         fun browser(browser: Browser): Builder = apply { this.browser = browser }
         fun stackCreationTimeout(stackCreationTimeout: Duration): Builder = apply { this.stackCreationTimeout = stackCreationTimeout }
         fun instanceType(instanceType: InstanceType): Builder = apply { this.instanceType = instanceType }
+        fun sshCidrIp(sshCidrIp: String): Builder = apply { this.sshCidrIp = sshCidrIp }
         internal fun network(network: Network): Builder = apply { this.network = network }
 
         fun build(): StackVirtualUsersFormula = StackVirtualUsersFormula(
@@ -186,7 +193,8 @@ class StackVirtualUsersFormula private constructor(
             browser = browser,
             stackCreationTimeout = stackCreationTimeout,
             overriddenNetwork = network,
-            instanceType = instanceType
+            instanceType = instanceType,
+            sshCidrIp = sshCidrIp
         )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
@@ -55,7 +55,8 @@ class StackVirtualUsersFormula private constructor(
         splunkForwarder = splunkForwarder,
         browser = browser,
         stackCreationTimeout = Duration.ofMinutes(30),
-        instanceType = InstanceType.C48xlarge
+        instanceType = InstanceType.C48xlarge,
+        sshCidrIp = ""
     )
 
     @Deprecated(message = "Use StackVirtualUsersFormula.Builder instead.")
@@ -67,7 +68,8 @@ class StackVirtualUsersFormula private constructor(
         splunkForwarder = DisabledSplunkForwarder(),
         browser = Chrome(),
         stackCreationTimeout = Duration.ofMinutes(30),
-        instanceType = InstanceType.C48xlarge
+        instanceType = InstanceType.C48xlarge,
+        sshCidrIp = ""
     )
 
     @Deprecated(message = "Use StackVirtualUsersFormula.Builder instead.")
@@ -80,7 +82,8 @@ class StackVirtualUsersFormula private constructor(
         splunkForwarder = splunkForwarder,
         browser = Chrome(),
         stackCreationTimeout = Duration.ofMinutes(30),
-        instanceType = InstanceType.C48xlarge
+        instanceType = InstanceType.C48xlarge,
+        sshCidrIp = ""
     )
 
     override fun provision(

--- a/src/main/resources/aws/virtual-users.yaml
+++ b/src/main/resources/aws/virtual-users.yaml
@@ -15,6 +15,11 @@ Parameters:
     Type: String
   InstanceType:
     Type: String
+  SSHCidrIp:
+    Description: CIDR IP range of SSH access to be allowed in the security group
+    Type: String
+Conditions:
+  SetSSHCidrIp: !Not [!Equals [!Ref SSHCidrIp, ""]]
 Resources:
   VirtualUsers:
     Type: AWS::EC2::Instance
@@ -51,4 +56,5 @@ Resources:
           IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: 0.0.0.0/0
+          CidrIp:
+            !If [SetSSHCidrIp, !Ref SSHCidrIp, 0.0.0.0/0]


### PR DESCRIPTION
The jces-1209 (JPT for cloud) will be running for EAP (Early access program) customer and as per security requirement, we need to restrict the cidr ip range for SSH ingress traffic, so I added the code change in this PR to create the ability to parameterise cidr ip via cloudformation parameters to `build/resources/main/aws/virtual-users.yaml`. 
If no value is supplied it will fallback to original value `0.0.0.0/0` so this feature will not affect existing usage of this CF.

@dmewada-atlas previously shared our solution plan in #help-jpt channel, but let me know if you need it again then will share it.
Thanks

Related EAN ticket : https://ecosystem.atlassian.net/browse/JPERF-733