### PR TITLE
JPERF-733: add missing variable to virtual-users parameter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,13 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.2...master
+[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.23.0...master
+
+### Fixed
+- Fixed a bug which does not override CIDR IP range of SSH ingress to virtual user EC2 nodes for `virtual-users.yaml`
+
+## [2.23.0] - 2021-04-16
+[2.23.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.22.2...release-2.23.0
 
 ### Added
 - Add the ability to parameterize CIDR IP range of SSH ingress to virtual user EC2 nodes for `virtual-users.yaml`

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
@@ -120,7 +120,7 @@ class StackVirtualUsersFormula private constructor(
                     .withParameterValue(instanceType.toString()),
                 Parameter()
                     .withParameterKey("SSHCidrIp")
-                    .withParameterValue("")
+                    .withParameterValue(sshCidrIp)
             ),
             aws = aws,
             pollingTimeout = stackCreationTimeout


### PR DESCRIPTION
Hi, this PR is to patch a fix to my previous PR https://github.com/atlassian/aws-infrastructure/pull/110 (https://ecosystem.atlassian.net/browse/JPERF-733). 
Previously I used `.withParameterValue("")` instead of `.withParameterValue(sshCidrIp)`.