### PR TITLE
JPERF-792: Fix Jira Data Center testing for pre version 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
 
+### Fixed
+- Grant load balancer access to every Jira node provisioned by `DataCenterFormula`. Fix [JPERF-792].
+
+[JPERF-792]: https://ecosystem.atlassian.net/browse/JPERF-792
+
 ## [2.25.2] - 2022-01-21
 [2.25.2]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.1...release-2.25.2
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
@@ -295,6 +295,10 @@ class DataCenterFormula private constructor(
             MultiAccessRequester(jiraNodes.map { ForIpAccessRequester { it.publicIpAddress } })
                 .requestAccess(jiraNodeRmiAccessProvider)
         }
+        val selfDashboardAccess = executor.submitWithLogContext("self dashboard access") {
+            MultiAccessRequester(jiraNodes.map { ForIpAccessRequester { it.publicIpAddress } })
+                .requestAccess(provisionedLoadBalancer.accessProvider)
+        }
         val loadBalancerAccess = executor.submitWithLogContext("load balancer access") {
             provisionedLoadBalancer.accessRequester.requestAccess(jiraNodeHttpAccessProvider)
         }
@@ -331,6 +335,9 @@ class DataCenterFormula private constructor(
 
         if (!rmiNodePublicAccess.get()) {
             logger.warn("Jira nodes may not have access to other nodes RMI ports. This can cause slow Jira startup.")
+        }
+        if (!selfDashboardAccess.get()) {
+            logger.warn("It's possible that Jira nodes don't have HTTP access to the load balancer. Dashboards may not work.")
         }
         if (!loadBalancerAccess.get()) {
             logger.warn("Load balancer may not have access to Jira nodes")


### PR DESCRIPTION
This was missed when reporting and fixing JPERF-790.

For Jira pre 8.9.0 if the instance has no access to its own HTTP the dashboard view may freeze (in our case it was after log in, however it may be related to dataset config).

This access to self is described as required in the setup documentation https://confluence.atlassian.com/jirakb/configure-linux-firewall-for-jira-applications-741933610.html and it was missed in implementation of aws-infrastructure 2.24.0

> 4 - Allowing connections to JIRA from itself (to ensure you don't run into problems with [gadget titles showing as __MSG_gadget](https://confluence.atlassian.com/jirakb/fix-gadget-titles-showing-as-__msg_gadget-in-jira-server-813697086.html))
> ```iptables -t nat -I OUTPUT -p tcp -o lo --dport 80 -j REDIRECT --to-ports 8080```