### PR TITLE
JPERF-760: Print Jira logs when failed to start a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.5...master
 
+### Added
+- Allow to diagnose the Jira node startup problems by printing atlassian-jira.log inside test log. Resolve [JPERF-760]
+
+[JPERF-760]: https://ecosystem.atlassian.net/browse/JPERF-760
+
 ## [2.25.5] - 2022-04-07
 [2.25.5]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.4...release-2.25.5
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
@@ -153,6 +153,13 @@ internal data class StandaloneStoppedNode(
                 break
             }
             if (deadline < now()) {
+                if (logger.isDebugEnabled) {
+                    val logContent = ssh.safeExecute(
+                        cmd = "cat $jiraHome/log/atlassian-jira.log",
+                        timeout = ofMinutes(3)
+                    ).output
+                    logger.debug("Jira log file: <<$logContent>>")
+                }
                 throw Exception("$uri failed to get out of $statusQuo status within $timeout")
             }
             threadDump.gather(ssh, "thread-dumps")


### PR DESCRIPTION
Currently if I'm not missing something we are not collecting any artifacts if `InfrastructureFormula` fails to provision (throws an `Exception`). When we fail to wait on Jira node to start then the process throws an `Exception` and in the result makes us unable to diagnose why the failure happened in the first place, because we are not getting handle on `ProvisionedInfrastructure`.

I though that we may want to just print the Jira logs in the JPT's `detailed.log`. It should not cause much harm.

I'm looking for feedback.