### PR TITLE
JPERF-188 Fix stopping Jira while saving a dataset by replacing tomcat shutdown command with 'stop-jira.sh' script.

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/AwsDatasetModification.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/AwsDatasetModification.kt
@@ -70,7 +70,8 @@ class AwsDatasetModification private constructor(
             database = jira.database ?: throw Exception("The database should have been provisioned")
         ).build()
         val storedDataset = source.store(
-            aws.customDatasetStorage(newDatasetName).location
+            aws.customDatasetStorage(newDatasetName).location,
+            jira
         )
         logger.info("Dataset $newDatasetName persisted")
         return storedDataset
@@ -143,7 +144,9 @@ class AwsDatasetModification private constructor(
          */
         fun host(host: DatasetHost) = apply { this.host = host }
 
-        fun onlineTransformation(onlineTransformation: Consumer<Infrastructure<*>>) = apply { this.onlineTransformation = onlineTransformation }
+        fun onlineTransformation(onlineTransformation: Consumer<Infrastructure<*>>) =
+            apply { this.onlineTransformation = onlineTransformation }
+
         fun workspace(workspace: TestWorkspace) = apply { this.workspace = workspace }
         fun newDatasetName(newDatasetName: String) = apply { this.newDatasetName = newDatasetName }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
@@ -37,5 +37,9 @@ class Jira(
         executor.shutdownNow()
     }
 
+    fun stop() {
+        nodes.forEach { it.stopNode() }
+    }
+
     override fun toString() = "Jira(address=$address)"
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
@@ -61,7 +61,8 @@ internal data class StandaloneStoppedNode(
                     resultsTransport = resultsTransport,
                     unpackedProduct = unpackedProduct,
                     monitoringProcesses = monitoringProcesses,
-                    ssh = ssh
+                    ssh = ssh,
+                    jdk = jdk
                 ).gatherResults()
                 throw Exception("Failed to start the Jira node.", exception)
             }
@@ -76,7 +77,8 @@ internal data class StandaloneStoppedNode(
             resultsTransport = resultsTransport,
             unpackedProduct = unpackedProduct,
             monitoringProcesses = monitoringProcesses,
-            ssh = ssh
+            ssh = ssh,
+            jdk = jdk
         )
     }
 


### PR DESCRIPTION
Using a dedicated script being a part of Jira product is a recommended way to stop an instance.