### PR TITLE
JPERF-945: Reproduce the Kotlin metadata bug

### DIFF
--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.817
 com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -12,7 +12,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.817
 com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.amazonaws:aws-java-sdk-sts:1.11.817
 com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
-com.atlassian.performance.tools:aws-resources:1.9.1
+com.atlassian.performance.tools:aws-resources:1.10.1
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:infrastructure:4.22.2
 com.atlassian.performance.tools:io:1.2.0


### PR DESCRIPTION
Rewrite locks: `./gradlew dep --write-locks`.
As you can see, the newest `aws-resources` in the declared range _is_ `1.10.1`. The "is" means "as of the time of this commit",
so you might have a different result if you repeat it later on. Luckily dependency locks let us freeze this moment in time.

To see the broken compatibility, run `./gradlew compileTestKotlin`.