### PR TITLE
JPERF-925: Use IAM role from `Aws` in EC2 LB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Added
 - Use `aws.defaultAmi` in `StackVirtualUsersFormula`. Resolve [JPERF-951].
+- Use `aws.shortTermStorageAccess` in `ApacheEc2LoadBalancerFormula`. Resolve [JPERF-952].
 
 [JPERF-951]: https://ecosystem.atlassian.net/browse/JPERF-951
+[JPERF-952]: https://ecosystem.atlassian.net/browse/JPERF-952
 
 ## [2.25.8] - 2022-08-12
 [2.25.8]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.7...release-2.25.8

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/loadbalancer/ApacheEc2LoadBalancerFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/loadbalancer/ApacheEc2LoadBalancerFormula.kt
@@ -13,6 +13,9 @@ class ApacheEc2LoadBalancerFormula : LoadBalancerFormula {
     private val logger: Logger = LogManager.getLogger(this::class.java)
     private val balancerPort = 80
 
+    /**
+     * @param aws provides `shortTermStorageAccess` IAM role used for LB nodes
+     */
     override fun provision(
         investment: Investment,
         instances: List<Instance>,
@@ -40,6 +43,7 @@ class ApacheEc2LoadBalancerFormula : LoadBalancerFormula {
                     .withSecurityGroupIds(securityGroup.groupId)
                     .withSubnetId(subnet.subnetId)
                     .withInstanceType(InstanceType.M5Large)
+                    .withIamInstanceProfile(IamInstanceProfileSpecification().withName(aws.shortTermStorageAccess()))
             }
         )
         key.file.facilitateSsh(ssh.host.ipAddress)


### PR DESCRIPTION
LB didn't use `shortTermStorageAccess` before, because it didn't need access to short term storage.
However, `aws-resources` doesn't model IAM well.
Its `shortTermStorage` access is already abused to grant permissions to:
- short term storage
- splunk forwarder

Here were widening the tech debt, but we're not deepening it.

Approach to IAM needs to be redesigned.