### PR TITLE
JPERF-968 Add ability to use a long term AWS credentials in the pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: eu-west-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Compile
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Replace the hardcoded region with environment variable.

The preferred way for authenticating in AWS is using IAM role, but 3rd party contributors might prefer using a key pair and with the previous config the key pair would not be picked up in the pipeline.