### PR TITLE
JPERF-997: network stack housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Added
 - Return the AWS `Resource` allocated by `NetworkFormula` as `ProvisionedNetwork`.
-- Open `Network` for inheritance.
+
+### Deprecated
+- Deprecate `NetworkFormula.provision` in favor of `NetworkFormula.provisionAsResource`.
 
 ### Fixed
 - Substitute the lost `DatasetCatalogue().largeJiraEight()` with an equivalent. Fix [JPERF-980].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.26.0...master
 
+### Added
+- Return the AWS `Resource` allocated by `NetworkFormula` as `ProvisionedNetwork`.
+- Open `Network` for inheritance.
+
 ### Fixed
 - Substitute the lost `DatasetCatalogue().largeJiraEight()` with an equivalent. Fix [JPERF-980].
   JQL data might be bigger than in the original. Requires Jira v8.22.0 or higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
   JQL data might be bigger than in the original. Requires Jira v8.22.0 or higher.
 - Track AWS resources from `ProvisionedNetwork` for release.
 - Stop spamming INFO log with network internals.
+- Stop double-logging network provisioning.
 
 [JPERF-980]: https://ecosystem.atlassian.net/browse/JPERF-980
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Substitute the lost `DatasetCatalogue().largeJiraEight()` with an equivalent. Fix [JPERF-980].
   JQL data might be bigger than in the original. Requires Jira v8.22.0 or higher.
+- Track AWS resources from `ProvisionedNetwork` for release.
 
 [JPERF-980]: https://ecosystem.atlassian.net/browse/JPERF-980
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 - Substitute the lost `DatasetCatalogue().largeJiraEight()` with an equivalent. Fix [JPERF-980].
   JQL data might be bigger than in the original. Requires Jira v8.22.0 or higher.
 - Track AWS resources from `ProvisionedNetwork` for release.
+- Stop spamming INFO log with network internals.
 
 [JPERF-980]: https://ecosystem.atlassian.net/browse/JPERF-980
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -73,9 +73,10 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
         }
 
         logger.info("Provisioning network...")
-        val network = CloseableThreadContext.push("network").use {
-            NetworkFormula(investment, aws).reuseOrProvision(preProvisionedNetwork).network
+        val provisionedNetwork = CloseableThreadContext.push("network").use {
+            NetworkFormula(investment, aws).reuseOrProvision(preProvisionedNetwork)
         }
+        val network = provisionedNetwork.network
         logger.info("Network ready.")
 
         val provisionJira = executor.submitWithLogContext("jira") {
@@ -129,6 +130,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
                     listOf(
                         provisionedJira.resource,
                         provisionedVirtualUsers.resource,
+                        provisionedNetwork.resource,
                         sshKey.remote
                     )
                 )

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -1,9 +1,6 @@
 package com.atlassian.performance.tools.awsinfrastructure.api
 
-import com.atlassian.performance.tools.aws.api.Aws
-import com.atlassian.performance.tools.aws.api.CompositeResource
-import com.atlassian.performance.tools.aws.api.Investment
-import com.atlassian.performance.tools.aws.api.SshKeyFormula
+import com.atlassian.performance.tools.aws.api.*
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.DataCenterFormula
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.JiraFormula
 import com.atlassian.performance.tools.awsinfrastructure.api.jira.JiraSoftwareDevDistribution
@@ -76,7 +73,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
 
         logger.info("Provisioning network...")
         val network = preProvisionedNetwork ?: executor.submitWithLogContext("network") {
-            NetworkFormula(investment, aws).provision()
+            NetworkFormula(investment, aws).provisionAsResource().network
         }.get()
         logger.info("Network ready.")
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -74,7 +74,7 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
 
         logger.info("Provisioning network...")
         val network = CloseableThreadContext.push("network").use {
-            preProvisionedNetwork ?:  NetworkFormula(investment, aws).provisionAsResource().network
+            NetworkFormula(investment, aws).reuseOrProvision(preProvisionedNetwork).network
         }
         logger.info("Network ready.")
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -72,12 +72,10 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
             ).provision()
         }
 
-        logger.info("Provisioning network...")
         val provisionedNetwork = CloseableThreadContext.push("network").use {
             NetworkFormula(investment, aws).reuseOrProvision(preProvisionedNetwork)
         }
         val network = provisionedNetwork.network
-        logger.info("Network ready.")
 
         val provisionJira = executor.submitWithLogContext("jira") {
             overrideJiraNetwork(network).provision(

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/InfrastructureFormula.kt
@@ -15,6 +15,7 @@ import com.atlassian.performance.tools.awsinfrastructure.virtualusers.S3ResultsT
 import com.atlassian.performance.tools.concurrency.api.submitWithLogContext
 import com.atlassian.performance.tools.infrastructure.api.virtualusers.VirtualUsers
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.logging.log4j.CloseableThreadContext
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.nio.file.Path
@@ -72,9 +73,9 @@ class InfrastructureFormula<out T : VirtualUsers> private constructor(
         }
 
         logger.info("Provisioning network...")
-        val network = preProvisionedNetwork ?: executor.submitWithLogContext("network") {
-            NetworkFormula(investment, aws).provisionAsResource().network
-        }.get()
+        val network = CloseableThreadContext.push("network").use {
+            preProvisionedNetwork ?:  NetworkFormula(investment, aws).provisionAsResource().network
+        }
         logger.info("Network ready.")
 
         val provisionJira = executor.submitWithLogContext("jira") {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
@@ -129,7 +129,7 @@ class DataCenterFormula private constructor(
                 .setNameFormat("data-center-provisioning-thread-%d")
                 .build()
         )
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
+        val network = NetworkFormula(investment, aws).reuseOrProvision(overriddenNetwork).network
         val template = TemplateBuilder("2-nodes-dc.yaml").adaptTo(configs)
         val stackProvisioning = executor.submitWithLogContext("provision stack") {
             StackFormula(

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
@@ -129,7 +129,7 @@ class DataCenterFormula private constructor(
                 .setNameFormat("data-center-provisioning-thread-%d")
                 .build()
         )
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provision()
+        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
         val template = TemplateBuilder("2-nodes-dc.yaml").adaptTo(configs)
         val stackProvisioning = executor.submitWithLogContext("provision stack") {
             StackFormula(

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
@@ -118,7 +118,7 @@ class StandaloneFormula private constructor(
                 .setNameFormat("standalone-provisioning-thread-%d")
                 .build()
         )
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provision()
+        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
         val template = TemplateBuilder("single-node.yaml").adaptTo(listOf(config))
 
         val stackProvisioning = executor.submitWithLogContext("provision stack") {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
@@ -118,7 +118,7 @@ class StandaloneFormula private constructor(
                 .setNameFormat("standalone-provisioning-thread-%d")
                 .build()
         )
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
+        val network = NetworkFormula(investment, aws).reuseOrProvision(overriddenNetwork).network
         val template = TemplateBuilder("single-node.yaml").adaptTo(listOf(config))
 
         val stackProvisioning = executor.submitWithLogContext("provision stack") {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/Network.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/Network.kt
@@ -6,7 +6,7 @@ import com.amazonaws.services.ec2.model.Vpc
 /**
  * @since 2.14.0
  */
-open class Network(
+class Network(
     val vpc: Vpc,
     val subnet: Subnet
 ) {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/Network.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/Network.kt
@@ -6,7 +6,7 @@ import com.amazonaws.services.ec2.model.Vpc
 /**
  * @since 2.14.0
  */
-class Network(
+open class Network(
     val vpc: Vpc,
     val subnet: Subnet
 ) {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
@@ -35,7 +35,8 @@ class NetworkFormula(
             stack.findVpc("Vpc"),
             stack.findSubnet("TheOnlySubnet")
         )
-        logger.info("Network provisioned: $network")
+        logger.info("Network provisioned")
+        logger.debug("Network provisioned: $network")
         return ProvisionedNetwork(network, stack)
     }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
@@ -17,7 +17,7 @@ class NetworkFormula(
 ) {
     private val logger = LogManager.getLogger(this::class.java)
 
-    fun provision(): ProvisionedNetwork {
+    fun provisionAsResource(): ProvisionedNetwork {
         val stackFormula = StackFormula(
             investment = investment,
             aws = aws,
@@ -37,4 +37,10 @@ class NetworkFormula(
         logger.info("Network provisioned: $network")
         return ProvisionedNetwork(network, stack)
     }
+
+    @Deprecated(
+        "Allocates AWS resources, use provisionAsResource to release the resource",
+        ReplaceWith("provisionAsResource().network")
+    )
+    fun provision(): Network = provisionAsResource().network
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
@@ -17,7 +17,7 @@ class NetworkFormula(
 ) {
     private val logger = LogManager.getLogger(this::class.java)
 
-    fun provision(): Network {
+    fun provision(): ProvisionedNetwork {
         val stackFormula = StackFormula(
             investment = investment,
             aws = aws,
@@ -35,6 +35,6 @@ class NetworkFormula(
             stack.findSubnet("TheOnlySubnet")
         )
         logger.info("Network provisioned: $network")
-        return network
+        return ProvisionedNetwork(network, stack)
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormula.kt
@@ -4,6 +4,7 @@ import com.amazonaws.services.cloudformation.model.Parameter
 import com.atlassian.performance.tools.aws.api.Aws
 import com.atlassian.performance.tools.aws.api.Investment
 import com.atlassian.performance.tools.aws.api.StackFormula
+import com.atlassian.performance.tools.aws.api.UnallocatedResource
 import com.atlassian.performance.tools.awsinfrastructure.pickAvailabilityZone
 import com.atlassian.performance.tools.io.api.readResourceText
 import org.apache.logging.log4j.LogManager
@@ -36,6 +37,14 @@ class NetworkFormula(
         )
         logger.info("Network provisioned: $network")
         return ProvisionedNetwork(network, stack)
+    }
+
+    internal fun reuseOrProvision(existing: Network?) : ProvisionedNetwork {
+        return if (existing != null) {
+            ProvisionedNetwork(existing, UnallocatedResource())
+        } else {
+            provisionAsResource()
+        }
     }
 
     @Deprecated(

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/ProvisionedNetwork.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/ProvisionedNetwork.kt
@@ -1,0 +1,13 @@
+package com.atlassian.performance.tools.awsinfrastructure.api.network
+
+import com.atlassian.performance.tools.aws.api.Resource
+
+class ProvisionedNetwork(
+    network: Network,
+    private val resource: Resource
+) : Network(network.vpc, network.subnet), Resource by resource {
+
+    override fun toString(): String {
+        return "ProvisionedNetwork(network=${super.toString()}, resource=$resource)"
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/ProvisionedNetwork.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/ProvisionedNetwork.kt
@@ -3,11 +3,6 @@ package com.atlassian.performance.tools.awsinfrastructure.api.network
 import com.atlassian.performance.tools.aws.api.Resource
 
 class ProvisionedNetwork(
-    network: Network,
-    private val resource: Resource
-) : Network(network.vpc, network.subnet), Resource by resource {
-
-    override fun toString(): String {
-        return "ProvisionedNetwork(network=${super.toString()}, resource=$resource)"
-    }
-}
+    val network: Network,
+    val resource: Resource
+)

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
@@ -97,7 +97,7 @@ class StackVirtualUsersFormula private constructor(
         aws: Aws
     ): ProvisionedVirtualUsers<SshVirtualUsers> {
         logger.debug("Setting up $name...")
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
+        val network = NetworkFormula(investment, aws).reuseOrProvision(overriddenNetwork).network
         val virtualUsersStack = StackFormula(
             investment = investment,
             cloudformationTemplate = readResourceText("aws/virtual-users.yaml"),

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/StackVirtualUsersFormula.kt
@@ -97,7 +97,7 @@ class StackVirtualUsersFormula private constructor(
         aws: Aws
     ): ProvisionedVirtualUsers<SshVirtualUsers> {
         logger.debug("Setting up $name...")
-        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provision()
+        val network = overriddenNetwork ?: NetworkFormula(investment, aws).provisionAsResource().network
         val virtualUsersStack = StackFormula(
             investment = investment,
             cloudformationTemplate = readResourceText("aws/virtual-users.yaml"),

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/aws/AwsCliIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/aws/AwsCliIT.kt
@@ -40,7 +40,7 @@ class AwsCliIT {
             lifespan = lifespan
         )
         val networkFormula = NetworkFormula(investment, aws)
-        val network = networkFormula.provision()
+        val network = networkFormula.provisionAsResource().network
         sshInstance = aws.awaitingEc2.allocateInstance(
             investment = investment,
             key = keyFormula.provision(),

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/aws/AwsCliIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/aws/AwsCliIT.kt
@@ -7,6 +7,7 @@ import com.atlassian.performance.tools.aws.api.SshInstance
 import com.atlassian.performance.tools.aws.api.SshKeyFormula
 import com.atlassian.performance.tools.awsinfrastructure.IntegrationTestRuntime
 import com.atlassian.performance.tools.awsinfrastructure.api.network.NetworkFormula
+import com.atlassian.performance.tools.awsinfrastructure.api.network.ProvisionedNetwork
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.Before
@@ -23,6 +24,7 @@ class AwsCliIT {
     private val aws = IntegrationTestRuntime.aws
     private lateinit var executor: ExecutorService
     private lateinit var sshInstance: SshInstance
+    private lateinit var provisionedNetwork: ProvisionedNetwork
 
     @Before
     fun setUp() {
@@ -40,7 +42,8 @@ class AwsCliIT {
             lifespan = lifespan
         )
         val networkFormula = NetworkFormula(investment, aws)
-        val network = networkFormula.provisionAsResource().network
+        provisionedNetwork = networkFormula.provisionAsResource()
+        val network = provisionedNetwork.network
         sshInstance = aws.awaitingEc2.allocateInstance(
             investment = investment,
             key = keyFormula.provision(),
@@ -57,6 +60,7 @@ class AwsCliIT {
     @After
     fun cleanUp() {
         sshInstance.resource.release()
+        provisionedNetwork.resource.release()
         executor.shutdownNow()
     }
 

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormulaIT.kt
@@ -16,7 +16,7 @@ class NetworkFormulaIT {
             lifespan = Duration.ofMinutes(10)
         )
 
-        val network = NetworkFormula(investment, aws).provision()
-        network.release().get(4, MINUTES)
+        val network = NetworkFormula(investment, aws).provisionAsResource()
+        network.resource.release().get(4, MINUTES)
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/network/NetworkFormulaIT.kt
@@ -1,0 +1,22 @@
+package com.atlassian.performance.tools.awsinfrastructure.api.network
+
+import com.atlassian.performance.tools.aws.api.Investment
+import com.atlassian.performance.tools.awsinfrastructure.IntegrationTestRuntime.aws
+import org.junit.Test
+import java.time.Duration
+import java.util.concurrent.TimeUnit.MINUTES
+
+class NetworkFormulaIT {
+
+    @Test
+    fun shouldReleaseResources() {
+        aws.cleanLeftovers()
+        val investment = Investment(
+            useCase = "test NetworkFormula",
+            lifespan = Duration.ofMinutes(10)
+        )
+
+        val network = NetworkFormula(investment, aws).provision()
+        network.release().get(4, MINUTES)
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/Ec2VirtualUsersFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/virtualusers/Ec2VirtualUsersFormulaIT.kt
@@ -31,7 +31,7 @@ class Ec2VirtualUsersFormulaIT {
         )
 
         Ec2VirtualUsersFormula.Builder(jar)
-            .network(networkFormula.provision())
+            .network(networkFormula.provisionAsResource().network)
             .instanceType(InstanceType.C59xlarge)
             .build()
             .provision(


### PR DESCRIPTION
The main reason for this PR is `NetworkFormulaIT` as a way to test network creation and housekeeping without spinning up unnecessary EC2 instances.