### PR TITLE
JPERF-980: Substitute the lost Jira 8 dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.26.0...master
 
+### Fixed
+- Substitute the lost `DatasetCatalogue().largeJiraEight()` with an equivalent. Fix [JPERF-980].
+  JQL data might be bigger than in the original. Requires Jira v8.22.0 or higher.
+
+[JPERF-980]: https://ecosystem.atlassian.net/browse/JPERF-980
+
 ## [2.26.0] - 2022-02-01
 [2.26.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.8...release-2.26.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
@@ -36,19 +36,22 @@ class DatasetCatalogue {
         )
     }
 
+    /**
+     * Contains data for Jira 8: v8.22.0 or higher.
+     */
     fun largeJiraEight(): Dataset {
-        val bucketUri = URI("https://s3.eu-central-1.amazonaws.com/jpt-custom-datasets-storage-a008820-datasetbucket-dah44h6l1l8p/")
+        val bucketUri = URI("https://s3.eu-central-1.amazonaws.com/jpt-custom-datasets-storage-a008820-datasetbucket-1nrja8d1upind/")
         return Dataset(
             label = "2M issues, format 8",
             database = MySqlDatabase(
                 HttpDatasetPackage(
-                    uri = bucketUri.resolve("dataset-631c70d4-084b-455c-9785-b01068b9f07c/database.tar.bz2"),
+                    uri = bucketUri.resolve("dataset-fa563790-84c2-4cdf-a49c-c5ca4b223c94/database.tar.bz2"),
                     downloadTimeout = ofMinutes(17)
                 )
             ),
             jiraHomeSource = JiraHomePackage(
                 HttpDatasetPackage(
-                    uri = bucketUri.resolve("dataset-631c70d4-084b-455c-9785-b01068b9f07c/jirahome.tar.bz2"),
+                    uri = bucketUri.resolve("dataset-fa563790-84c2-4cdf-a49c-c5ca4b223c94/jirahome.tar.bz2"),
                     downloadTimeout = ofMinutes(21)
                 )
             )

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormulaIT.kt
@@ -28,7 +28,7 @@ class DataCenterFormulaIT {
     private val workspace = IntegrationTestRuntime.taskWorkspace
     private val aws = IntegrationTestRuntime.aws
     private val jiraVersionSeven = "7.2.0"
-    private val jiraVersionEight = "8.0.0"
+    private val jiraVersionEight = "8.22.0"
     private val datasetSeven = DatasetCatalogue().smallJiraSeven()
     private val datasetEight = DatasetCatalogue().largeJiraEight()
 


### PR DESCRIPTION
Unfortunately, the new dataset doesn't work for Jira v8.0.0, it needs v8.22.0 or higher.
The lost dataset used to support v8.0.0.

It wasn't an explicit contract, so technically this isn't breaking declared compatibility. However, it was relied upon, so it was a de facto implicit contract.
So we hope to restore v8.0.0, and add that as a new explicit contract.