### PR TITLE
JPERF-996: Make it possible to handle waiting for Jira startup outside provisioning process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.8...master
 
+### Added
+- Make it possible to handle waiting for Jira startup outside provisioning process. Unblock [JPERF-996].
+
+### Fixed
+- Fix bug where accessRequester wouldn't be preserved when JiraFormula is used with InfrastructureFormula.
+
+[JPERF-996]: https://ecosystem.atlassian.net/browse/JPERF-996
+
 ## [2.25.8] - 2022-08-12
 [2.25.8]: https://github.com/atlassian/aws-infrastructure/compare/release-2.25.7...release-2.25.8
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
@@ -56,7 +56,8 @@ class DataCenterFormula private constructor(
     private val databaseComputer: Computer,
     private val databaseVolume: Volume,
     private val accessRequester: AccessRequester,
-    private val adminPasswordPlainText: String
+    private val adminPasswordPlainText: String,
+    private val waitForUpgrades: Boolean
 ) : JiraFormula {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -88,7 +89,8 @@ class DataCenterFormula private constructor(
         databaseComputer = M4ExtraLargeElastic(),
         databaseVolume = Volume(100),
         accessRequester = Defaults.accessRequester,
-        adminPasswordPlainText = Defaults.adminPasswordPlainText
+        adminPasswordPlainText = Defaults.adminPasswordPlainText,
+        waitForUpgrades = true
     )
 
     @Suppress("DEPRECATION")
@@ -111,7 +113,8 @@ class DataCenterFormula private constructor(
         databaseComputer = M4ExtraLargeElastic(),
         databaseVolume = Volume(100),
         accessRequester = Defaults.accessRequester,
-        adminPasswordPlainText = Defaults.adminPasswordPlainText
+        adminPasswordPlainText = Defaults.adminPasswordPlainText,
+        waitForUpgrades = true
     )
 
     override fun provision(
@@ -237,6 +240,7 @@ class DataCenterFormula private constructor(
                             pluginsTransport = pluginsTransport,
                             productDistribution = productDistribution,
                             ssh = ssh,
+                            waitForUpgrades = waitForUpgrades,
                             config = configs[i],
                             computer = computer,
                             adminPasswordPlainText = adminPasswordPlainText
@@ -403,6 +407,7 @@ class DataCenterFormula private constructor(
         private var databaseVolume: Volume = Volume(100)
         private var accessRequester: AccessRequester = Defaults.accessRequester
         private var adminPasswordPlainText: String = "admin"
+        private var waitForUpgrades: Boolean = true
 
         internal constructor(
             formula: DataCenterFormula
@@ -420,7 +425,9 @@ class DataCenterFormula private constructor(
             network = formula.overriddenNetwork
             databaseComputer = formula.databaseComputer
             databaseVolume = formula.databaseVolume
+            accessRequester = formula.accessRequester
             adminPasswordPlainText = formula.adminPasswordPlainText
+            waitForUpgrades = formula.waitForUpgrades
         }
 
         fun configs(configs: List<JiraNodeConfig>): Builder = apply { this.configs = configs }
@@ -447,6 +454,12 @@ class DataCenterFormula private constructor(
 
         fun accessRequester(accessRequester: AccessRequester) = apply { this.accessRequester = accessRequester }
 
+        /**
+         * Don't change when starting up multi-node Jira DC of version lower than 9.1.0
+         * See https://confluence.atlassian.com/jirakb/index-management-on-jira-start-up-1141500654.html for more details.
+         */
+        fun waitForUpgrades(waitForUpgrades: Boolean) = apply { this.waitForUpgrades = waitForUpgrades }
+
         fun build(): DataCenterFormula = DataCenterFormula(
             configs = configs,
             loadBalancerFormula = loadBalancerFormula,
@@ -461,7 +474,8 @@ class DataCenterFormula private constructor(
             databaseComputer = databaseComputer,
             databaseVolume = databaseVolume,
             accessRequester = accessRequester,
-            adminPasswordPlainText  = adminPasswordPlainText
+            adminPasswordPlainText  = adminPasswordPlainText,
+            waitForUpgrades = waitForUpgrades
         )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
@@ -48,7 +48,8 @@ class StandaloneFormula private constructor(
     private val databaseComputer: Computer,
     private val databaseVolume: Volume,
     private val accessRequester: AccessRequester,
-    private val adminPasswordPlainText: String
+    private val adminPasswordPlainText: String,
+    private val waitForUpgrades: Boolean
 ) : JiraFormula {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -77,7 +78,8 @@ class StandaloneFormula private constructor(
         databaseComputer = M4ExtraLargeElastic(),
         databaseVolume = Volume(100),
         accessRequester = Defaults.accessRequester,
-        adminPasswordPlainText = "admin"
+        adminPasswordPlainText = "admin",
+        waitForUpgrades = true
     )
 
     @Suppress("DEPRECATION")
@@ -99,7 +101,8 @@ class StandaloneFormula private constructor(
         databaseComputer = M4ExtraLargeElastic(),
         databaseVolume = Volume(100),
         accessRequester = Defaults.accessRequester,
-        adminPasswordPlainText = "admin"
+        adminPasswordPlainText = "admin",
+        waitForUpgrades = true
     )
 
     override fun provision(
@@ -191,7 +194,8 @@ class StandaloneFormula private constructor(
             productDistribution = productDistribution,
             ssh = jiraSsh,
             computer = computer,
-            adminPasswordPlainText  = adminPasswordPlainText
+            adminPasswordPlainText  = adminPasswordPlainText,
+            waitForUpgrades = waitForUpgrades
         )
 
         val jiraNodeSecurityGroup = jiraStack.findSecurityGroup("JiraNodeSecurityGroup")
@@ -307,6 +311,7 @@ class StandaloneFormula private constructor(
         private var databaseVolume: Volume = Volume(100)
         private var accessRequester: AccessRequester = Defaults.accessRequester
         private var adminPasswordPlainText: String = "admin"
+        private var waitForUpgrades: Boolean = true
 
         internal constructor(
             formula: StandaloneFormula
@@ -323,7 +328,9 @@ class StandaloneFormula private constructor(
             network = formula.overriddenNetwork
             databaseComputer = formula.databaseComputer
             databaseVolume = formula.databaseVolume
+            accessRequester = formula.accessRequester
             adminPasswordPlainText = formula.adminPasswordPlainText
+            waitForUpgrades = formula.waitForUpgrades
         }
 
         fun config(config: JiraNodeConfig): Builder = apply { this.config = config }
@@ -342,6 +349,8 @@ class StandaloneFormula private constructor(
 
         fun accessRequester(accessRequester: AccessRequester) = apply { this.accessRequester = accessRequester }
 
+        fun waitForUpgrades(waitForUpgrades: Boolean) = apply { this.waitForUpgrades = waitForUpgrades }
+
         fun build(): StandaloneFormula = StandaloneFormula(
             apps = apps,
             productDistribution = productDistribution,
@@ -355,7 +364,8 @@ class StandaloneFormula private constructor(
             databaseComputer = databaseComputer,
             databaseVolume = databaseVolume,
             accessRequester = accessRequester,
-            adminPasswordPlainText  = adminPasswordPlainText
+            adminPasswordPlainText  = adminPasswordPlainText,
+            waitForUpgrades = waitForUpgrades
         )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
@@ -28,6 +28,7 @@ internal class StandaloneNodeFormula(
     private val databaseIp: String,
     private val productDistribution: ProductDistribution,
     private val ssh: Ssh,
+    private val waitForUpgrades: Boolean,
     private val config: JiraNodeConfig,
     private val computer: Computer,
     private val adminPasswordPlainText: String
@@ -101,6 +102,7 @@ internal class StandaloneNodeFormula(
                     unpackedProduct = unpackedProduct,
                     osMetrics = osMetrics,
                     ssh = ssh,
+                    waitForUpgrades = waitForUpgrades,
                     launchTimeouts = config.launchTimeouts,
                     jdk = jdk,
                     profiler = config.profiler,

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
@@ -25,6 +25,7 @@ internal data class StandaloneStoppedNode(
     private val resultsTransport: Storage,
     private val unpackedProduct: String,
     private val osMetrics: List<OsMetric>,
+    private val waitForUpgrades: Boolean,
     private val launchTimeouts: JiraLaunchTimeouts,
     private val jdk: JavaDevelopmentKit,
     private val profiler: Profiler,
@@ -107,6 +108,11 @@ internal data class StandaloneStoppedNode(
         ssh: SshConnection,
         threadDump: ThreadDump
     ) {
+        if (!waitForUpgrades) {
+            logger.debug("Skipping Jira startup wait")
+            return
+        }
+        logger.debug("Waiting for Jira node to start...")
         val upgradesEndpoint = URI("http://admin:${adminPasswordPlainText}@localhost:8080/rest/api/2/upgrade")
         waitForStatusToChange(
             statusQuo = "000",


### PR DESCRIPTION
When Jira is set up from scratch we can't rely on the current version of wait mechanism as it assumes Jira will run upgrade tasks before it's interactive.