### PR TITLE
JPERF-1047: Stop overriding content of `jira-config.properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Stop logging ERRORs while `LocalPublicIpv4Provider` expects services to fail.
 - Prevent JVM process from hanging after failing inside `StandaloneFormula` or `DataCenterFormula` due to not cleaned up resources. Fix [JPERF-1042].
+- Stop overriding content of `jirahome/jira-config.properties` when using `StandaloneFormula` or `DataCenterFormula`. Fix [JPERF-1047].
 
 [JPERF-990]: https://ecosystem.atlassian.net/browse/JPERF-990
 [JPERF-1042]: https://ecosystem.atlassian.net/browse/JPERF-1042
+[JPERF-1047]: https://ecosystem.atlassian.net/browse/JPERF-1047
 
 ## [2.28.0] - 2023-03-01
 [2.28.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.27.0...release-2.28.0

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneNodeFormula.kt
@@ -74,7 +74,8 @@ internal class StandaloneNodeFormula(
                     jiraIp = ssh.host.ipAddress
                 )
                 connection.execute("echo jira.home=`realpath $jiraHome` > $unpackedProduct/atlassian-jira/WEB-INF/classes/jira-application.properties")
-                connection.execute("echo jira.autoexport=false > $jiraHome/jira-config.properties")
+                connection.execute("sed -i '/^jira.autoexport=/d' $jiraHome/jira-config.properties")
+                connection.execute("echo jira.autoexport=false >> $jiraHome/jira-config.properties")
                 downloadMysqlConnector(
                     "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz",
                     connection


### PR DESCRIPTION
With this we can preserve some configuration applied to the config file, e.g. disabling of web sudo. Such configuration can also happen dynamically as part of `JiraHomeSource` instalation.

Verified sed behavior locally using ubuntu in docker:
```
[14:00:46] pczuj:~ $ docker run -ti --entrypoint /bin/bash ubuntu
root@a1d37950f8e7:/# mkdir jiraHome
root@a1d37950f8e7:/# echo jira.autoexport=false >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
jira.autoexport=false
root@a1d37950f8e7:/# sed -i '/jira.autoexport=/d' jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
root@a1d37950f8e7:/# echo jira.autoexport=false >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# echo jira.autoexport=true >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# echo jira.autoexport2=true >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# echo not.jira.autoexport=true >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
jira.autoexport=false
jira.autoexport=true
jira.autoexport2=true
not.jira.autoexport=true
root@a1d37950f8e7:/# sed -i '/jira.autoexport=/d' jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
jira.autoexport2=true
root@a1d37950f8e7:/# echo not.jira.autoexport=true >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# echo jira.autoexport=true >> jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
jira.autoexport2=true
not.jira.autoexport=true
jira.autoexport=true
root@a1d37950f8e7:/# sed -i '/^jira.autoexport=/d' jiraHome/jira-config.properties
root@a1d37950f8e7:/# cat jiraHome/jira-config.properties
jira.autoexport2=true
not.jira.autoexport=true
root@a1d37950f8e7:/#
```