### PR TITLE
JPERF-1079 Make it possible to stop Jira nodes with a dedicated script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-2.29.0...master
 
+### Remove
+- Remove deprecated constructors of `CustomDatasetSource`.
+- Remove `Jira` constructor.
+- Remove `Jira.getDatabase`.
+- Remove `CustomDatasetSource.Builder` constructor with two parameters.
+
+### Added
+- Add `StoppableNode` class to allow stopping nodes in a uniform way. Fix [JPERF-188].
+- Serialize `StoppableNode` to JSON.
+- Add `Jira.Builder`.
+- Add `Jira.toDatasetSource` function.
+- Add `CustomDatasetSource.Builder` constructor with additional `List<StoppableNode>` parameter.
+
+[JPERF-188]: https://ecosystem.atlassian.net/browse/JPERF-188
 ### Fixed
 - Change default virtual user instance type to `c5.9xlarge`. It's better, cheaper and there seem to be availability issues with previous default (`c4.8xlarge`).
 

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -14,7 +14,7 @@ com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jvm-tasks:1.2.4

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -14,7 +14,7 @@ com.amazonaws:aws-java-sdk-support:1.11.817
 com.amazonaws:jmespath-java:1.11.817
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jvm-tasks:1.2.4

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.amazonaws:jmespath-java:1.11.817
 com.atlassian.data:random-data:1.4.3
 com.atlassian.performance.tools:aws-resources:1.11.2
 com.atlassian.performance.tools:concurrency:1.2.1
-com.atlassian.performance.tools:infrastructure:4.24.0
+com.atlassian.performance.tools:infrastructure:4.24.1
 com.atlassian.performance.tools:io:1.2.0
 com.atlassian.performance.tools:jira-actions:3.18.1
 com.atlassian.performance.tools:jira-software-actions:1.4.2

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/AwsDatasetModification.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/AwsDatasetModification.kt
@@ -66,14 +66,10 @@ class AwsDatasetModification private constructor(
         jira: Jira
     ): Dataset {
         logger.info("Persisting the $newDatasetName dataset ...")
-        val jiraHome = jira.jiraHome
-        val database = jira.database ?: throw Exception("The database should have been provisioned")
-        val source = CustomDatasetSource.Builder(jiraHome, database)
+        val source = jira.toDatasetSource()
             .also { datasetSourceConfig.accept(it) }
             .build()
-        val storedDataset = source.store(
-            aws.customDatasetStorage(newDatasetName).location
-        )
+        val storedDataset = source.store(aws.customDatasetStorage(newDatasetName).location)
         logger.info("Dataset $newDatasetName persisted")
         return storedDataset
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
@@ -1,7 +1,7 @@
 package com.atlassian.performance.tools.awsinfrastructure.api
 
 import com.atlassian.performance.tools.aws.api.StorageLocation
-import com.atlassian.performance.tools.awsinfrastructure.api.jira.StartedNode
+import com.atlassian.performance.tools.awsinfrastructure.api.jira.StoppableNode
 import com.atlassian.performance.tools.concurrency.api.submitWithLogContext
 import com.atlassian.performance.tools.infrastructure.api.dataset.Dataset
 import com.atlassian.performance.tools.ssh.api.Ssh
@@ -19,7 +19,7 @@ class CustomDatasetSource private constructor(
     val database: RemoteLocation,
     private val jiraHomeTimeouts: Timeouts,
     private val databaseTimeouts: Timeouts,
-    private val nodes: List<StartedNode.StoppableNode>
+    private val nodes: List<StoppableNode>
 ) {
 
     object FileNames {
@@ -90,7 +90,7 @@ class CustomDatasetSource private constructor(
     }
 
     private fun stopJira() {
-        nodes.forEach { it.stopNode() }
+        nodes.forEach { it.stop() }
     }
 
     private fun stopDockerContainers(host: SshHost) {
@@ -110,7 +110,7 @@ class CustomDatasetSource private constructor(
     class Builder(
         private var jiraHome: RemoteLocation,
         private var database: RemoteLocation,
-        private var nodes: List<StartedNode.StoppableNode>
+        private var nodes: List<StoppableNode>
     ) {
         private var jiraHomeArchiveTimeout: Duration = Duration.ofMinutes(25)
         private var jiraHomeUploadTimeout: Duration = Duration.ofMinutes(10)
@@ -122,7 +122,7 @@ class CustomDatasetSource private constructor(
         constructor(json: JsonObject) : this(
             jiraHome = RemoteLocation(json.getJsonObject("jiraHome")),
             database = RemoteLocation(json.getJsonObject("database")),
-            nodes = json.getJsonArray("nodes").map { StartedNode.StoppableNode.Builder(it.asJsonObject()).build() }
+            nodes = json.getJsonArray("nodes").map { StoppableNode.Builder(it.asJsonObject()).build() }
         )
 
 
@@ -146,7 +146,7 @@ class CustomDatasetSource private constructor(
         fun databaseMoveTimeout(databaseMoveTimeout: Duration) =
             apply { this.databaseMoveTimeout = databaseMoveTimeout }
 
-        fun nodes(nodes: List<StartedNode.StoppableNode>) = apply { this.nodes = nodes }
+        fun nodes(nodes: List<StoppableNode>) = apply { this.nodes = nodes }
 
         fun build() = CustomDatasetSource(
             jiraHome,

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormula.kt
@@ -382,16 +382,18 @@ class DataCenterFormula private constructor(
             loadBalancer.waitUntilHealthy(Duration.ofMinutes(5))
         }
 
-        val jira = Jira(
+        val jira = Jira.Builder(
             nodes = nodes,
             jiraHome = RemoteLocation(
                 sharedHomeSsh.host,
                 sharedHome.get().remoteSharedHome
             ),
             database = databaseDataLocation,
-            address = loadBalancer.uri,
-            jmxClients = jiraNodes.mapIndexed { i, node -> configs[i].remoteJmx.getClient(node.publicIpAddress) }
+            address = loadBalancer.uri
         )
+            .jmxClients(jiraNodes.mapIndexed { i, node -> configs[i].remoteJmx.getClient(node.publicIpAddress) })
+            .build()
+
         logger.info("$jira is set up, will expire ${jiraStack.expiry}")
         return ProvisionedJira.Builder(jira)
             .resource(
@@ -427,7 +429,8 @@ class DataCenterFormula private constructor(
             database = database
         )
 
-        private var configs: List<JiraNodeConfig> = (1..2).map { JiraNodeConfig.Builder().name("jira-node-$it").build() }
+        private var configs: List<JiraNodeConfig> =
+            (1..2).map { JiraNodeConfig.Builder().name("jira-node-$it").build() }
         private var loadBalancerFormula: LoadBalancerFormula = ApacheEc2LoadBalancerFormula()
         private var apps: Apps = Apps(emptyList())
         private var computer: Computer = C4EightExtraLargeElastic()
@@ -479,7 +482,8 @@ class DataCenterFormula private constructor(
 
         fun databaseVolume(databaseVolume: Volume): Builder = apply { this.databaseVolume = databaseVolume }
 
-        fun adminPasswordPlainText(adminPasswordPlainText: String): Builder = apply { this.adminPasswordPlainText = adminPasswordPlainText }
+        fun adminPasswordPlainText(adminPasswordPlainText: String): Builder =
+            apply { this.adminPasswordPlainText = adminPasswordPlainText }
 
         internal fun network(network: Network) = apply { this.network = network }
 
@@ -505,7 +509,7 @@ class DataCenterFormula private constructor(
             databaseComputer = databaseComputer,
             databaseVolume = databaseVolume,
             accessRequester = accessRequester,
-            adminPasswordPlainText  = adminPasswordPlainText,
+            adminPasswordPlainText = adminPasswordPlainText,
             waitForUpgrades = waitForUpgrades
         )
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.awsinfrastructure.api.jira
 
+import com.atlassian.performance.tools.awsinfrastructure.api.CustomDatasetSource
 import com.atlassian.performance.tools.awsinfrastructure.api.RemoteLocation
 import com.atlassian.performance.tools.concurrency.api.submitWithLogContext
 import com.atlassian.performance.tools.infrastructure.api.MeasurementSource
@@ -14,7 +15,7 @@ import java.util.concurrent.Executors
 class Jira(
     private val nodes: List<StartedNode>,
     val jiraHome: RemoteLocation,
-    val database: RemoteLocation?,
+    val database: RemoteLocation,
     val address: URI,
     val jmxClients: List<JmxClient> = emptyList()
 ) : MeasurementSource {
@@ -37,5 +38,31 @@ class Jira(
         executor.shutdownNow()
     }
 
+    fun toDatasetSource(): CustomDatasetSource.Builder {
+        return CustomDatasetSource.Builder(
+            jiraHome = jiraHome,
+            database = database,
+            nodes = nodes.map { it.toStoppableNode() }
+        )
+    }
+
     override fun toString() = "Jira(address=$address)"
+
+    class Builder(
+        private val nodes: List<StartedNode>,
+        private val jiraHome: RemoteLocation,
+        private val database: RemoteLocation,
+        private val address: URI
+    ) {
+        private var jmxClients: List<JmxClient> = emptyList()
+        fun jmxClients(jmxClients: List<JmxClient>) = apply { this.jmxClients = jmxClients }
+
+        fun build() = Jira(
+            nodes = nodes,
+            jiraHome = jiraHome,
+            database = database,
+            address = address,
+            jmxClients = jmxClients
+        )
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/Jira.kt
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Logger
 import java.net.URI
 import java.util.concurrent.Executors
 
-class Jira(
+class Jira private constructor(
     private val nodes: List<StartedNode>,
     val jiraHome: RemoteLocation,
     val database: RemoteLocation,

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormula.kt
@@ -220,7 +220,7 @@ class StandaloneFormula private constructor(
             productDistribution = productDistribution,
             ssh = jiraSsh,
             computer = computer,
-            adminPasswordPlainText  = adminPasswordPlainText,
+            adminPasswordPlainText = adminPasswordPlainText,
             waitForUpgrades = waitForUpgrades
         )
 
@@ -291,16 +291,18 @@ class StandaloneFormula private constructor(
             logger.warn("It's possible that defined external access to Jira resources (e.g. http, debug, splunk) wasn't granted.")
         }
 
-        val jira = Jira(
+        val jira = Jira.Builder(
             nodes = listOf(node),
             jiraHome = RemoteLocation(
                 jiraSsh.host,
                 provisionedNode.jiraHome
             ),
             database = databaseDataLocation,
-            address = jiraPublicHttpAddress,
-            jmxClients = listOf(config.remoteJmx.getClient(jiraPublicIp))
+            address = jiraPublicHttpAddress
         )
+            .jmxClients(listOf(config.remoteJmx.getClient(jiraPublicIp)))
+            .build()
+
         logger.info("$jira is set up, will expire ${jiraStack.expiry}")
         return ProvisionedJira.Builder(jira)
             .resource(
@@ -313,7 +315,7 @@ class StandaloneFormula private constructor(
             .build()
     }
 
-    class Builder constructor(
+    class Builder(
         private val productDistribution: ProductDistribution,
         private val jiraHomeSource: JiraHomeSource,
         private val database: Database
@@ -372,7 +374,8 @@ class StandaloneFormula private constructor(
         fun databaseComputer(databaseComputer: Computer): Builder = apply { this.databaseComputer = databaseComputer }
         fun databaseVolume(databaseVolume: Volume): Builder = apply { this.databaseVolume = databaseVolume }
 
-        fun adminPasswordPlainText(adminPasswordPlainText: String): Builder = apply { this.adminPasswordPlainText = adminPasswordPlainText }
+        fun adminPasswordPlainText(adminPasswordPlainText: String): Builder =
+            apply { this.adminPasswordPlainText = adminPasswordPlainText }
 
         internal fun network(network: Network) = apply { this.network = network }
 
@@ -393,7 +396,7 @@ class StandaloneFormula private constructor(
             databaseComputer = databaseComputer,
             databaseVolume = databaseVolume,
             accessRequester = accessRequester,
-            adminPasswordPlainText  = adminPasswordPlainText,
+            adminPasswordPlainText = adminPasswordPlainText,
             waitForUpgrades = waitForUpgrades
         )
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
@@ -5,14 +5,17 @@ import com.atlassian.performance.tools.awsinfrastructure.api.aws.AwsCli
 import com.atlassian.performance.tools.infrastructure.api.jira.JiraGcLog
 import com.atlassian.performance.tools.infrastructure.api.process.RemoteMonitoringProcess
 import com.atlassian.performance.tools.ssh.api.Ssh
+import com.atlassian.performance.tools.ssh.api.SshHost
 import java.time.Duration
+import javax.json.Json
+import javax.json.JsonObject
 
 class StartedNode(
     private val name: String,
     private val jiraHome: String,
     private val analyticLogs: String,
     private val resultsTransport: Storage,
-    private val unpackedProduct: String,
+    private val jiraPath: String,
     private val monitoringProcesses: List<RemoteMonitoringProcess>,
     private val ssh: Ssh
 ) {
@@ -22,15 +25,15 @@ class StartedNode(
         ssh.newConnection().use { shell ->
             monitoringProcesses.forEach { it.stop(shell) }
             val nodeResultsDirectory = "$resultsDirectory/'$name'"
-            val threadDumpsFolder =  "thread-dumps"
+            val threadDumpsFolder = "thread-dumps"
             listOf(
                 "mkdir -p $nodeResultsDirectory",
-                "cp $unpackedProduct/logs/catalina.out $nodeResultsDirectory",
-                "cp $unpackedProduct/logs/*access* $nodeResultsDirectory",
+                "cp $jiraPath/logs/catalina.out $nodeResultsDirectory",
+                "cp $jiraPath/logs/*access* $nodeResultsDirectory",
                 "mkdir -p $nodeResultsDirectory/$threadDumpsFolder",
                 "cp $threadDumpsFolder/* $nodeResultsDirectory/$threadDumpsFolder",
                 "cp $jiraHome/log/atlassian-jira.log $nodeResultsDirectory",
-                "cp ${JiraGcLog(unpackedProduct).path()} $nodeResultsDirectory",
+                "cp ${JiraGcLog(jiraPath).path()} $nodeResultsDirectory",
                 "cp /var/log/syslog $nodeResultsDirectory",
                 "cp /var/log/cloud-init.log $nodeResultsDirectory",
                 "cp /var/log/cloud-init-output.log $nodeResultsDirectory"
@@ -66,11 +69,61 @@ class StartedNode(
             jiraHome = this.jiraHome,
             analyticLogs = analyticLogs,
             resultsTransport = this.resultsTransport,
-            unpackedProduct = this.unpackedProduct,
+            jiraPath = this.jiraPath,
             monitoringProcesses = this.monitoringProcesses,
             ssh = this.ssh
         )
     }
 
     override fun toString() = name
+
+    fun toStoppableNode(): StoppableNode {
+        return StoppableNode.Builder(
+            jiraPath = jiraPath,
+            ssh = ssh
+        ).build()
+    }
+
+    class StoppableNode private constructor(
+        private val jiraPath: String,
+        private val ssh: Ssh
+    ) {
+        fun stopNode() {
+            ssh.newConnection().use { ssh ->
+                ssh.execute(
+                    """
+                    |source ~/.profile
+                    |${jiraPath}/bin/stop-jira.sh
+                    """.trimMargin(),
+                    Duration.ofMinutes(3)
+                )
+            }
+        }
+
+        fun toJson(): JsonObject {
+            return Json.createObjectBuilder()
+                .add("jiraPath", jiraPath)
+                .add("ssh", ssh.host.toJson())
+                .build()
+        }
+
+        class Builder(
+            private var jiraPath: String,
+            private var ssh: Ssh
+        ) {
+            constructor(json: JsonObject) : this(
+                jiraPath = json.getString("jiraPath"),
+                ssh = Ssh(
+                    SshHost(json.getJsonObject("ssh"))
+                )
+            )
+
+            fun jiraPath(jiraPath: String) = apply { this.jiraPath = jiraPath }
+            fun ssh(ssh: Ssh) = apply { this.ssh = ssh }
+            fun build() = StoppableNode(
+                jiraPath = jiraPath,
+                ssh = ssh
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
@@ -5,10 +5,7 @@ import com.atlassian.performance.tools.awsinfrastructure.api.aws.AwsCli
 import com.atlassian.performance.tools.infrastructure.api.jira.JiraGcLog
 import com.atlassian.performance.tools.infrastructure.api.process.RemoteMonitoringProcess
 import com.atlassian.performance.tools.ssh.api.Ssh
-import com.atlassian.performance.tools.ssh.api.SshHost
 import java.time.Duration
-import javax.json.Json
-import javax.json.JsonObject
 
 class StartedNode(
     private val name: String,
@@ -77,53 +74,5 @@ class StartedNode(
 
     override fun toString() = name
 
-    fun toStoppableNode(): StoppableNode {
-        return StoppableNode.Builder(
-            jiraPath = jiraPath,
-            ssh = ssh
-        ).build()
-    }
-
-    class StoppableNode private constructor(
-        private val jiraPath: String,
-        private val ssh: Ssh
-    ) {
-        fun stopNode() {
-            ssh.newConnection().use { ssh ->
-                ssh.execute(
-                    """
-                    |source ~/.profile
-                    |${jiraPath}/bin/stop-jira.sh
-                    """.trimMargin(),
-                    Duration.ofMinutes(3)
-                )
-            }
-        }
-
-        fun toJson(): JsonObject {
-            return Json.createObjectBuilder()
-                .add("jiraPath", jiraPath)
-                .add("ssh", ssh.host.toJson())
-                .build()
-        }
-
-        class Builder(
-            private var jiraPath: String,
-            private var ssh: Ssh
-        ) {
-            constructor(json: JsonObject) : this(
-                jiraPath = json.getString("jiraPath"),
-                ssh = Ssh(
-                    SshHost(json.getJsonObject("ssh"))
-                )
-            )
-
-            fun jiraPath(jiraPath: String) = apply { this.jiraPath = jiraPath }
-            fun ssh(ssh: Ssh) = apply { this.ssh = ssh }
-            fun build() = StoppableNode(
-                jiraPath = jiraPath,
-                ssh = ssh
-            )
-        }
-    }
+    fun toStoppableNode(): StoppableNode = StoppableNode.Builder(jiraPath, ssh).build()
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StoppableNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StoppableNode.kt
@@ -1,0 +1,44 @@
+package com.atlassian.performance.tools.awsinfrastructure.api.jira
+
+import com.atlassian.performance.tools.ssh.api.Ssh
+import com.atlassian.performance.tools.ssh.api.SshHost
+import java.time.Duration
+import javax.json.Json
+import javax.json.JsonObject
+
+class StoppableNode private constructor(
+    private val jiraPath: String,
+    private val ssh: Ssh
+) {
+    fun stop() {
+        ssh.newConnection().use { ssh ->
+            ssh.execute("source ~/.profile; ${jiraPath}/bin/stop-jira.sh", Duration.ofMinutes(3))
+        }
+    }
+
+    fun toJson(): JsonObject {
+        return Json.createObjectBuilder()
+            .add("jiraPath", jiraPath)
+            .add("ssh", ssh.host.toJson())
+            .build()
+    }
+
+    class Builder(
+        private var jiraPath: String,
+        private var ssh: Ssh
+    ) {
+        constructor(json: JsonObject) : this(
+            jiraPath = json.getString("jiraPath"),
+            ssh = Ssh(
+                SshHost(json.getJsonObject("ssh"))
+            )
+        )
+
+        fun jiraPath(jiraPath: String) = apply { this.jiraPath = jiraPath }
+        fun ssh(ssh: Ssh) = apply { this.ssh = ssh }
+        fun build() = StoppableNode(
+            jiraPath = jiraPath,
+            ssh = ssh
+        )
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/UriJiraFormula.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/UriJiraFormula.kt
@@ -1,6 +1,9 @@
 package com.atlassian.performance.tools.awsinfrastructure.api.jira
 
-import com.atlassian.performance.tools.aws.api.*
+import com.atlassian.performance.tools.aws.api.Aws
+import com.atlassian.performance.tools.aws.api.Investment
+import com.atlassian.performance.tools.aws.api.SshKey
+import com.atlassian.performance.tools.aws.api.Storage
 import com.atlassian.performance.tools.awsinfrastructure.api.RemoteLocation
 import com.atlassian.performance.tools.ssh.api.SshHost
 import com.atlassian.performance.tools.ssh.api.auth.PasswordAuthentication
@@ -20,20 +23,25 @@ class UriJiraFormula(
         aws: Aws
     ): ProvisionedJira = ProvisionedJira
         .Builder(
-            Jira(
+            Jira.Builder(
                 nodes = emptyList(),
-                jiraHome = RemoteLocation(
-                    host = SshHost(
-                        ipAddress = "unknown",
-                        userName = "unknown",
-                        authentication = PasswordAuthentication("unknown"),
-                        port = -1
-                    ),
-                    location = "unknown"
-                ),
-                database = null,
+                jiraHome = dummyRemoteLocation(),
+                database = dummyRemoteLocation(),
                 address = jiraAddress
             )
+                .build()
         )
         .build()
+
+    private fun dummyRemoteLocation(): RemoteLocation {
+        return RemoteLocation(
+            host = SshHost(
+                ipAddress = "unknown",
+                userName = "unknown",
+                authentication = PasswordAuthentication("unknown"),
+                port = -1
+            ),
+            location = "unknown"
+        )
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/jira/StandaloneStoppedNode.kt
@@ -60,7 +60,7 @@ internal data class StandaloneStoppedNode(
                     jiraHome = jiraHome,
                     analyticLogs = analyticLogs,
                     resultsTransport = resultsTransport,
-                    unpackedProduct = unpackedProduct,
+                    jiraPath = unpackedProduct,
                     monitoringProcesses = monitoringProcesses,
                     ssh = ssh
                 ).gatherResults()
@@ -75,7 +75,7 @@ internal data class StandaloneStoppedNode(
             jiraHome = jiraHome,
             analyticLogs = analyticLogs,
             resultsTransport = resultsTransport,
-            unpackedProduct = unpackedProduct,
+            jiraPath = unpackedProduct,
             monitoringProcesses = monitoringProcesses,
             ssh = ssh
         )


### PR DESCRIPTION
- Remove deprecated constructors of Jira and CustomDatasetSource. 
- Add to Jira information about its nodes.
- Add the ability to stop Jira nodes using a dedicated script (this part requires having JAVA_HOME set)