### PR TITLE
Let `StartedNode.gatherResults` finish despite failure in `stop` of `RemoteMonitoringProcess`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Change default virtual user instance type to `c5.9xlarge`. It's better, cheaper and there seem to be availability issues with previous default (`c4.8xlarge`).
+- Let `StartedNode.gatherResults` finish despite failure in `stop` of `RemoteMonitoringProcess`. Fix [JPERF-1117].
+
+[JPERF-1117]: https://ecosystem.atlassian.net/browse/JPERF-1117
 
 ## [2.29.0] - 2023-03-24
 [2.29.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.28.0...release-2.29.0


### PR DESCRIPTION
I know it would be better to just fix the `stop` for every `RemoteMonitoringProcess`, however I don't think it should prevent all results gathering if only the `RemoteMonitoringProcess` is faulty. Especially that [we don't fail a test if the results are not gathered](https://github.com/atlassian/aws-infrastructure/blob/c10ced8d753892203c3630bafeb3f1eec491ff89/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/Infrastructure.kt#L68).