### PR TITLE
JPERF-1117: Let `StartedNode.gatherResults` finish despite failure in `stop` of `RemoteMonitoringProcess`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.0.0...master
 
+### Fixed
+- Let `StartedNode.gatherResults` finish despite failure in `stop` of `RemoteMonitoringProcess`. Fix [JPERF-1117].
+
+[JPERF-1117]: https://ecosystem.atlassian.net/browse/JPERF-1117
+
 ## [3.0.0] - 2023-05-25
 [3.0.0]: https://github.com/atlassian/aws-infrastructure/compare/release-2.29.0...release-3.0.0
 


### PR DESCRIPTION
Revive of #164 

> I know it would be better to just fix the stop for every RemoteMonitoringProcess, however I don't think it should prevent all results gathering if only the RemoteMonitoringProcess is faulty. Especially that [we don't fail a test if the results are not gathered](https://github.com/atlassian/aws-infrastructure/blob/c10ced8d753892203c3630bafeb3f1eec491ff89/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/Infrastructure.kt#L68).