### PR TITLE
issue/JPERF-1190-gather-all-jira-log-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.0.1...master
+### Fixed
+- Gather all `atlassian-jira.log` files from `StartedNode`. Fix [JPERF-1190].
+
+[JPERF-1120]: https://ecosystem.atlassian.net/browse/JPERF-1190
 
 ## [3.0.1] - 2023-06-22
 [3.0.1]: https://github.com/atlassian/aws-infrastructure/compare/release-3.0.0...release-3.0.1

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StartedNode.kt
@@ -37,7 +37,7 @@ class StartedNode(
                 "cp $jiraPath/logs/*access* $nodeResultsDirectory",
                 "mkdir -p $nodeResultsDirectory/$threadDumpsFolder",
                 "cp $threadDumpsFolder/* $nodeResultsDirectory/$threadDumpsFolder",
-                "cp $jiraHome/log/atlassian-jira.log $nodeResultsDirectory",
+                "cp $jiraHome/log/atlassian-jira.log* $nodeResultsDirectory",
                 "cp ${JiraGcLog(jiraPath).path()} $nodeResultsDirectory",
                 "cp /var/log/syslog $nodeResultsDirectory",
                 "cp /var/log/cloud-init.log $nodeResultsDirectory",


### PR DESCRIPTION
Gather all `atlassian-jira.log` files including those with number suffix like `atlassian-jira.log.1`