### PR TITLE
Issue/jperf 1184 stop docker containers for real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.0.1...master
 
+### Added
+- Add `DatasetCatalogue().smallJiraNine()`. Unblock [JPERF-1184].
+
+### Fixed
+- Add missing `sudo` to `CustomDatasetSource.stopDockerContainers` to avoid permission errors. Fix [JPERF-1184].
+
+[JPERF-1184] https://ecosystem.atlassian.net/browse/JPERF-1184
+
 ## [3.0.1] - 2023-06-22
 [3.0.1]: https://github.com/atlassian/aws-infrastructure/compare/release-3.0.0...release-3.0.1
 

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSource.kt
@@ -94,7 +94,7 @@ class CustomDatasetSource private constructor(
     }
 
     private fun stopDockerContainers(host: SshHost) {
-        Ssh(host, connectivityPatience = 4).newConnection().use { it.safeExecute("docker stop \$(docker ps -aq)") }
+        Ssh(host, connectivityPatience = 4).newConnection().use { it.execute("sudo docker stop \$(sudo docker ps -aq)") }
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/DatasetCatalogue.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.awsinfrastructure.api
 
+import com.amazonaws.regions.Regions
 import com.atlassian.performance.tools.aws.api.StorageLocation
 import com.atlassian.performance.tools.awsinfrastructure.api.dataset.S3DatasetPackage
 import com.atlassian.performance.tools.infrastructure.api.database.LicenseOverridingMysql
@@ -76,6 +77,17 @@ class DatasetCatalogue {
                 ))
             )
         }
+
+    fun smallJiraNine(): Dataset = DatasetCatalogue().custom(
+        location = StorageLocation(
+            URI("s3://jpt-custom-datasets-storage-a008820-datasetbucket-1nrja8d1upind/")
+                .resolve("parent/v01-disable-backup-service-aa9bfcd4-68f2-4836-8271-d128b3c9fa0a/child/v01-publish-8.20.0-66b31acf-1a1b-40bd-b650-d15f79674bf0"),
+            Regions.EU_CENTRAL_1
+        ),
+        label = "1k issues",
+        databaseDownload = ofMinutes(5),
+        jiraHomeDownload = ofMinutes(5)
+    )
 
     fun custom(
         location: StorageLocation,

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSourceIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSourceIT.kt
@@ -1,0 +1,65 @@
+package com.atlassian.performance.tools.awsinfrastructure.api
+
+import com.atlassian.performance.tools.aws.api.Investment
+import com.atlassian.performance.tools.aws.api.SshKeyFormula
+import com.atlassian.performance.tools.awsinfrastructure.IntegrationTestRuntime
+import com.atlassian.performance.tools.awsinfrastructure.IntegrationTestRuntime.aws
+import com.atlassian.performance.tools.awsinfrastructure.api.jira.ProvisionedJira
+import com.atlassian.performance.tools.awsinfrastructure.api.jira.StandaloneFormula
+import com.atlassian.performance.tools.infrastructure.api.distribution.PublicJiraSoftwareDistribution
+import com.atlassian.performance.tools.ssh.api.Ssh
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.time.Duration
+import java.util.*
+import java.util.concurrent.CompletableFuture
+
+class CustomDatasetSourceIT {
+    private val workspace = IntegrationTestRuntime.taskWorkspace.isolateTest(javaClass.simpleName)
+    private val nonce = UUID.randomUUID().toString()
+
+    @Test
+    fun shouldStopDatabaseDockerContainer() {
+        //given
+        val provisionedJira = provisionStandaloneJira()
+        val datasetSource = provisionedJira.jira.toDatasetSource().build()
+
+        //when
+        datasetSource.store(aws.customDatasetStorage(nonce).location)
+
+        //then
+        val databaseSsh = Ssh(datasetSource.database.host)
+        val use = databaseSsh.newConnection().use { ssh ->
+            return@use ssh.execute("sudo docker ps -q")
+        }
+        assertThat(use.output).isEmpty()
+    }
+
+    private fun provisionStandaloneJira(): ProvisionedJira {
+        val sourceDataset = DatasetCatalogue().smallJiraNine()
+        val lifespan = Duration.ofHours(1)
+        val keyFormula = SshKeyFormula(
+            ec2 = aws.ec2,
+            workingDirectory = workspace.directory,
+            lifespan = lifespan,
+            prefix = nonce
+        )
+        return StandaloneFormula.Builder(
+            database = sourceDataset.database,
+            jiraHomeSource = sourceDataset.jiraHomeSource,
+            productDistribution = PublicJiraSoftwareDistribution("9.9.0")
+        )
+            .build()
+            .provision(
+                investment = Investment(
+                    useCase = "Test CustomDatasetSource",
+                    lifespan = lifespan
+                ),
+                pluginsTransport = aws.jiraStorage(nonce),
+                resultsTransport = aws.resultsStorage(nonce),
+                key = CompletableFuture.completedFuture(keyFormula.provision()),
+                roleProfile = aws.shortTermStorageAccess(),
+                aws = aws
+            )
+    }
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSourceIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/CustomDatasetSourceIT.kt
@@ -29,10 +29,10 @@ class CustomDatasetSourceIT {
 
         //then
         val databaseSsh = Ssh(datasetSource.database.host)
-        val use = databaseSsh.newConnection().use { ssh ->
-            return@use ssh.execute("sudo docker ps -q")
+        val containerList = databaseSsh.newConnection().use { ssh ->
+            ssh.execute("sudo docker ps -q")
         }
-        assertThat(use.output).isEmpty()
+        assertThat(containerList.output).isEmpty()
     }
 
     private fun provisionStandaloneJira(): ProvisionedJira {


### PR DESCRIPTION
Add sudo to CustomDatasetSource.stopDockerContainers. 
We suspect that when we fail to close the MySQL container and proceed with archiving the database, the data inside might be corrupted.