### PR TITLE
Mark 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.1.4...master
+[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.1.5...master
+
+## 3.1.5 - 2024-06-12
 
 ### Added
 - Wait for running status via:


### PR DESCRIPTION
I did tag release-3.2.0-alpha, but on the branch commit, not after the rebase/merge.

https://packages.atlassian.com/maven-central/com/atlassian/performance/tools/aws-infrastructure/3.1.5/