### PR TITLE
Mark 3.1.6 + bump via CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'Release? yes/no'
-        default: 'no'
+        type: choice
+        description: 'Bump SemVer and release?'
+        options:
+          - No
+          - Patch
+          - Minor
+          - Major
+        default: No
 
 jobs:
   build:
@@ -61,7 +67,7 @@ jobs:
       contents: write
       id-token: write
     needs: build-check
-    if: github.event.inputs.release == 'yes'
+    if: github.event.inputs.release != null && github.event.inputs.release != 'No'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -75,7 +81,6 @@ jobs:
           atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
           atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
         run: |
-          ./gradlew release \
-              -Prelease.customUsername=${{ github.actor }} \
-              -Prelease.customPassword=${{ github.token }}
+          ./gradlew markNextVersion -Prelease.incrementer=increment${{ github.event.inputs.release }} -Prelease.localOnly
+          ./gradlew release -Prelease.customUsername=${{ github.actor }} -Prelease.customPassword=${{ github.token }}
           ./gradlew publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ on:
         type: choice
         description: 'Bump SemVer and release?'
         options:
-          - No
+          - 'No'
           - Patch
           - Minor
           - Major
-        default: No
+        default: 'No'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.1.5...master
+[Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.1.6...master
 
+## 3.1.6 - 2024-06-12
 ## 3.1.5 - 2024-06-12
 
 ### Added


### PR DESCRIPTION
Yes, I made the same mistake twice in a row.
Gonna fix that in the next commit.

I made too many mistakes when bumping it manually via `git tag`.
Inspired by https://github.com/atlassian-labs/db-replica/commit/4f79ab27c5474dc45b5acb1d28ffec41c470719c

Before:
- `git tag` the appropriate commit
  - the one rebased by GitHub, not your local pre-pull-request commit
  - construct the tag name by hand, e.g. `release-3.2.0-alpha` minor bump
- `git push` the tag
- trigger GitHub Actions with "yes"

After:
- pick the bump type in GitHub actions
- trigger GitHub Actions with the bump type, e.g. "Minor"