### PR TITLE
Stop testing Jiras which require Oracle JDK 1.8

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/DataCenterFormulaIT.kt
@@ -7,18 +7,13 @@ import com.atlassian.performance.tools.awsinfrastructure.api.DatasetCatalogue
 import com.atlassian.performance.tools.awsinfrastructure.api.hardware.C5NineExtraLargeEphemeral
 import com.atlassian.performance.tools.concurrency.api.submitWithLogContext
 import com.atlassian.performance.tools.infrastructure.api.database.MinimalMysqlDatabase
-import com.atlassian.performance.tools.infrastructure.api.dataset.Dataset
 import com.atlassian.performance.tools.infrastructure.api.distribution.PublicJiraSoftwareDistribution
 import com.atlassian.performance.tools.infrastructure.api.jira.JiraNodeConfig
 import com.atlassian.performance.tools.infrastructure.api.jira.MinimalMysqlJiraHome
 import com.atlassian.performance.tools.infrastructure.api.jvm.OpenJDK
 import com.atlassian.performance.tools.infrastructure.api.jvm.jmx.EnabledRemoteJmx
-import com.atlassian.performance.tools.workspace.api.TaskWorkspace
-import com.atlassian.performance.tools.workspace.api.TestWorkspace
-import com.google.common.util.concurrent.ThreadFactoryBuilder
-import org.apache.logging.log4j.CloseableThreadContext
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Percentage
+import org.assertj.core.data.Percentage.withPercentage
 import org.junit.Test
 import java.lang.Thread.sleep
 import java.net.HttpURLConnection
@@ -27,16 +22,12 @@ import java.time.Duration
 import java.time.Duration.ofSeconds
 import java.util.*
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
+import java.util.concurrent.Executors.newFixedThreadPool
 import java.util.concurrent.TimeUnit
 
 class DataCenterFormulaIT {
     private val workspace = IntegrationTestRuntime.taskWorkspace
     private val aws = IntegrationTestRuntime.aws
-    private val jiraVersionSeven = "7.2.0"
-    private val jiraVersionEight = "8.22.0"
-    private val datasetSeven = DatasetCatalogue().smallJiraSeven()
-    private val datasetEight = DatasetCatalogue().largeJiraEight()
 
     /**
      * The default JDK in [JiraNodeConfig] is flaky to install.
@@ -47,174 +38,77 @@ class DataCenterFormulaIT {
 
     @Test
     fun shouldProvisionDataCenter() {
-        val executor = Executors.newFixedThreadPool(
-            2,
-            ThreadFactoryBuilder()
-                .setNameFormat("DCFIT-test-thread-%d")
-                .build()
+        val dataset = DatasetCatalogue().largeJiraEight()
+        val jiraVersion = "8.22.0"
+        val testWorkspace = workspace.isolateTest("shouldProvisionDataCenter")
+        val nonce = UUID.randomUUID().toString()
+        val lifespan = Duration.ofMinutes(30)
+        val keyFormula = SshKeyFormula(
+            ec2 = aws.ec2,
+            workingDirectory = testWorkspace.directory,
+            lifespan = lifespan,
+            prefix = nonce
         )
-        listOf(
-            DataCenterProvisioningTest(
-                jiraVersion = jiraVersionSeven,
-                dataset = datasetSeven
+        val nodeConfigs = JiraNodeConfig.Builder(stableJdk)
+            .remoteJmx(EnabledRemoteJmx())
+            .build()
+            .multipleNodes(2)
+        val dcFormula = DataCenterFormula.Builder(
+            productDistribution = PublicJiraSoftwareDistribution(jiraVersion),
+            jiraHomeSource = dataset.jiraHomeSource,
+            database = dataset.database
+        ).computer(C5NineExtraLargeEphemeral())
+            .databaseComputer(C5NineExtraLargeEphemeral())
+            .waitForRunning(true)
+            .configs(nodeConfigs)
+            .build()
+
+        val provisionedJira = dcFormula.provision(
+            investment = Investment(
+                useCase = "Test Data Center provisioning",
+                lifespan = lifespan
             ),
-            DataCenterJmxProvisioningTest(
-                jiraVersion = jiraVersionEight,
-                dataset = datasetEight
-            )
+            pluginsTransport = aws.jiraStorage(nonce),
+            resultsTransport = aws.resultsStorage(nonce),
+            key = CompletableFuture.completedFuture(keyFormula.provision()),
+            roleProfile = aws.shortTermStorageAccess(),
+            aws = aws
         )
-            .map { test ->
-                executor.submitWithLogContext(test.jiraVersion) {
-                    test.run(
-                        group = "DCFIT-test",
-                        workspace = workspace
-                    )
-                }
-            }
-            .forEach { it.get() }
-        executor.shutdownNow()
+
+        runLoadBalancerTest(provisionedJira.jira.address)
+        provisionedJira.jira.jmxClients.forEach { client ->
+            client.execute { connector -> assertThat(connector.mBeanServerConnection.mBeanCount).isGreaterThan(0) }
+        }
+
+        provisionedJira.resource.release().get(3, TimeUnit.MINUTES)
     }
 
-    private inner class DataCenterProvisioningTest(
-        override val jiraVersion: String,
-        private val dataset: Dataset
-    ) : GroupableTest("Data Center provisioning - Jira version $jiraVersion") {
-        override fun run(workspace: TestWorkspace) {
-            val nonce = UUID.randomUUID().toString()
-            val lifespan = Duration.ofMinutes(30)
-            val keyFormula = SshKeyFormula(
-                ec2 = aws.ec2,
-                workingDirectory = workspace.directory,
-                lifespan = lifespan,
-                prefix = nonce
-            )
-            val dcFormula = DataCenterFormula.Builder(
-                productDistribution = PublicJiraSoftwareDistribution(jiraVersion),
-                jiraHomeSource = dataset.jiraHomeSource,
-                database = dataset.database
-            ).computer(C5NineExtraLargeEphemeral())
-                .databaseComputer(C5NineExtraLargeEphemeral())
-                .waitForRunning(true)
-                .configs(stableJdk.multipleNodes(2))
-                .build()
+    private fun runLoadBalancerTest(address: URI) {
+        val executor = newFixedThreadPool(20) { Thread(it, "DCFIT-test-load-balancer-thread-$it") }
 
-            val provisionedJira = dcFormula.provision(
-                investment = Investment(
-                    useCase = "Test Data Center provisioning",
-                    lifespan = lifespan
-                ),
-                pluginsTransport = aws.jiraStorage(nonce),
-                resultsTransport = aws.resultsStorage(nonce),
-                key = CompletableFuture.completedFuture(keyFormula.provision()),
-                roleProfile = aws.shortTermStorageAccess(),
-                aws = aws
-            )
-
-            runLoadBalancerTest(provisionedJira.jira.address)
-
-            provisionedJira.resource.release().get(3, TimeUnit.MINUTES)
-        }
-
-        private fun runLoadBalancerTest(address: URI) {
-            val executor = Executors.newFixedThreadPool(
-                20,
-                ThreadFactoryBuilder()
-                    .setNameFormat("DCFIT-test-load-balancer-thread-%d")
-                    .build()
-            )
-
-            val routeIds = (1..1000).map {
-                executor.submitWithLogContext("Test") {
-                    getRouteId(address)
-                }
+        val routeIds = (1..1000).map {
+            executor.submitWithLogContext("Test") {
+                getRouteId(address)
             }
-                .map { it.get() }
-                .groupingBy { it }
-                .eachCount()
-
-            assertThat(routeIds.size).isEqualTo(2)
-
-            val counts = routeIds.entries.map { it.value }
-
-            assertThat(counts[0]).isCloseTo(counts[1], Percentage.withPercentage(10.0))
         }
+            .map { it.get() }
+            .groupingBy { it }
+            .eachCount()
 
-        private fun getRouteId(address: URI): String {
-            val cookiesList = address.toURL().openConnection().headerFields["Set-Cookie"]
+        assertThat(routeIds.size).isEqualTo(2)
 
-            assertThat(cookiesList).isNotNull
-
-            val routeId = cookiesList!!.filter { str ->
-                str.contains("ROUTEID")
-            }
-
-            assertThat(routeId.size).isEqualTo(1)
-
-            return routeId[0].split(";")[0]
-        }
+        val counts = routeIds.entries.map { it.value }
+        assertThat(counts[0]).isCloseTo(counts[1], withPercentage(10.0))
     }
 
-    private inner class DataCenterJmxProvisioningTest(
-        override val jiraVersion: String,
-        private val dataset: Dataset
-    ) : GroupableTest("Data Center with JMX provisioning - Jira version $jiraVersion") {
-        override fun run(workspace: TestWorkspace) {
-            val nonce = UUID.randomUUID().toString()
-            val lifespan = Duration.ofMinutes(30)
-            val keyFormula = SshKeyFormula(
-                ec2 = aws.ec2,
-                workingDirectory = workspace.directory,
-                lifespan = lifespan,
-                prefix = nonce
-            )
-            val config = JiraNodeConfig.Builder(stableJdk)
-                .remoteJmx(EnabledRemoteJmx())
-                .build()
-            val dcFormula = DataCenterFormula.Builder(
-                productDistribution = PublicJiraSoftwareDistribution(jiraVersion),
-                jiraHomeSource = dataset.jiraHomeSource,
-                database = dataset.database
-            ).computer(C5NineExtraLargeEphemeral())
-                .databaseComputer(C5NineExtraLargeEphemeral())
-                .configs(config.multipleNodes(2))
-                .build()
-
-            val provisionedJira = dcFormula.provision(
-                investment = Investment(
-                    useCase = "Test Data Center provisioning",
-                    lifespan = lifespan
-                ),
-                pluginsTransport = aws.jiraStorage(nonce),
-                resultsTransport = aws.resultsStorage(nonce),
-                key = CompletableFuture.completedFuture(keyFormula.provision()),
-                roleProfile = aws.shortTermStorageAccess(),
-                aws = aws
-            )
-            val resource = provisionedJira.resource
-
-            provisionedJira.jira.jmxClients.forEach { client ->
-                client.execute { connector -> assertThat(connector.mBeanServerConnection.mBeanCount).isGreaterThan(0) }
-            }
-
-            resource.release().get(3, TimeUnit.MINUTES)
+    private fun getRouteId(address: URI): String {
+        val cookiesList = address.toURL().openConnection().headerFields["Set-Cookie"]
+        assertThat(cookiesList).isNotNull()
+        val routeId = cookiesList!!.filter { str ->
+            str.contains("ROUTEID")
         }
-    }
-
-    private abstract class GroupableTest(
-        protected val feature: String
-    ) {
-        abstract val jiraVersion: String
-
-        fun run(
-            group: String,
-            workspace: TaskWorkspace
-        ) {
-            CloseableThreadContext.put("test", "$group : $feature").use {
-                run(workspace.isolateTest("$group - $feature"))
-            }
-        }
-
-        abstract fun run(workspace: TestWorkspace)
+        assertThat(routeId).hasSize(1)
+        return routeId[0].split(";")[0]
     }
 
     @Test
@@ -255,9 +149,13 @@ class DataCenterFormulaIT {
     private fun URI.queryHttp() = toURL().openConnection()
         .let { it as? HttpURLConnection }
         ?.let {
-            try { it.responseCode }
-            catch (e: Exception) { -1 }
-            finally { it.disconnect() }
+            try {
+                it.responseCode
+            } catch (e: Exception) {
+                -1
+            } finally {
+                it.disconnect()
+            }
         }
 }
 

--- a/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormulaIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/awsinfrastructure/api/jira/StandaloneFormulaIT.kt
@@ -45,7 +45,7 @@ class StandaloneFormulaIT {
             prefix = nonce
         )
         val serverFormula = StandaloneFormula.Builder(
-            productDistribution = PublicJiraServiceDeskDistribution("3.9.8"),
+            productDistribution = PublicJiraServiceDeskDistribution("3.16.0"),
             database = dataset.database,
             jiraHomeSource = dataset.jiraHomeSource
         ).computer(C5NineExtraLargeEphemeral())
@@ -109,8 +109,12 @@ class StandaloneFormulaIT {
     private fun URI.queryHttp() = toURL().openConnection()
         .let { it as? HttpURLConnection }
         ?.let {
-            try { it.responseCode }
-            catch (e: Exception) { -1 }
-            finally { it.disconnect() }
+            try {
+                it.responseCode
+            } catch (e: Exception) {
+                -1
+            } finally {
+                it.disconnect()
+            }
         }
 }


### PR DESCRIPTION
`OracleJDK` is flaky as hell. We just cannot make the tests pass, so we can't even release 3.2.0 with it.

JSW supports alternative JDKs since 8.0.0..
No, [7.6] does not support it, see the [explanation]. JSM supports it since 3.16.0.

[7.6]: https://confluence.atlassian.com/adminjiraserver076/supported-platforms-945110772.html [explanation]