### PR TITLE
Fix version incrementer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,5 +60,5 @@ jobs:
           ./gradlew release \
               -Prelease.customUsername=${{ github.actor }} \
               -Prelease.customPassword=${{ github.token }} \
-              -Prelease.incrementer=increment${{ github.event.inputs.release }}
+              -Prelease.versionIncrementer=increment${{ github.event.inputs.release }}
           ./gradlew publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/aws-infrastructure/compare/release-3.1.6...master
 
+## 3.1.7 - 2024-06-24
 ## 3.1.6 - 2024-06-12
 ## 3.1.5 - 2024-06-12
 


### PR DESCRIPTION
Confirmed locally:
```
./gradlew release -Prelease.versionIncrementer=incrementMinor -Prelease.dryRun

> Task :verifyRelease
DRY-RUN: uncommitted changes: false
Looking for uncommitted changes..
DRY-RUN: ahead of remote: true
Checking if branch is ahead of remote.. FAILED
Checking for snapshot versions..

> Task :release
Creating tag: release-3.2.0
DRY-RUN: creating tag with name: release-3.2.0
Pushing all to remote: origin
DRY-RUN: pushing to remote: origin
```